### PR TITLE
wazo-user: add the xivo-user-uuid back into the metadata

### DIFF
--- a/integration_tests/suite/test_wazo_user_backend.py
+++ b/integration_tests/suite/test_wazo_user_backend.py
@@ -21,7 +21,9 @@ class TestWazoUserBackend(WazoAuthTestCase):
                 xivo_user_uuid=user['uuid'],  # For API compatibility reason
                 acls=has_items('confd.#', 'plugind.#'),
                 session_uuid=uuid_(),
-                metadata=has_entries(pbx_user_uuid=user['uuid']),
+                metadata=has_entries(
+                    pbx_user_uuid=user['uuid'], xivo_user_uuid=user['uuid']
+                ),
             ),
         )
 

--- a/wazo_auth/plugins/metadata/default_user.py
+++ b/wazo_auth/plugins/metadata/default_user.py
@@ -33,6 +33,7 @@ class DefaultUser(BaseMetadata):
             'auth_id': user_uuid,
             'username': login,
             'pbx_user_uuid': user_uuid,
+            'xivo_user_uuid': user_uuid,  # For API compatibility
             'user_uuid': user_uuid,
             'xivo_uuid': self.get_xivo_uuid(args),
             'uuid': user_uuid,


### PR DESCRIPTION
avoid breaking the API