### PR TITLE
Pull request for WAZO-1250-https-removal

### DIFF
--- a/etc/wazo-auth/config.yml
+++ b/etc/wazo-auth/config.yml
@@ -35,11 +35,10 @@ rest_api:
   # The maximum number of threads in the webserver thread pool
   max_threads: 25
 
-  https:
-    listen: 0.0.0.0
-    port: 9497
-    certificate: /usr/share/xivo-certs/server.crt
-    private_key: /usr/share/xivo-certs/server.key
+  listen: 0.0.0.0
+  port: 9497
+  certificate: /usr/share/xivo-certs/server.crt
+  private_key: /usr/share/xivo-certs/server.key
 
     #CORS configuration. See Flask-CORS documentation for other values.
   cors:

--- a/integration_tests/assets/etc/wazo-auth/conf.d/asset.documentation.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/asset.documentation.yml
@@ -2,9 +2,8 @@ debug: True
 foreground: True
 log_filename: /tmp/wazo-auth.log
 rest_api:
-  https:
-    listen: 0.0.0.0
-    port: 9497
+  listen: 0.0.0.0
+  port: 9497
   cors:
     enabled: True
     allow_headers: [Content-Type, Authorization, X-Auth-Token]

--- a/integration_tests/assets/etc/wazo-auth/conf.d/asset.no_ssl_certificate.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/asset.no_ssl_certificate.yml
@@ -1,3 +1,2 @@
 rest_api:
-  https:
-    certificate: /missing_server.crt
+  certificate: /missing_server.crt

--- a/integration_tests/assets/etc/wazo-auth/conf.d/asset.no_ssl_key.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/asset.no_ssl_key.yml
@@ -1,3 +1,2 @@
 rest_api:
-  https:
-    private_key: /missing_server.key
+  private_key: /missing_server.key

--- a/integration_tests/suite/database/test_db_token.py
+++ b/integration_tests/suite/database/test_db_token.py
@@ -70,9 +70,10 @@ class TestTokenDAO(base.DAOTestCase):
     @fixtures.db.token()
     def test_delete_expired_tokens_and_sessions(self, token_1, token_2, token_3):
         with self._session_dao.new_session() as s:
-            expired_tokens, expired_sessions = (
-                self._token_dao.delete_expired_tokens_and_sessions()
-            )
+            (
+                expired_tokens,
+                expired_sessions,
+            ) = self._token_dao.delete_expired_tokens_and_sessions()
 
             assert_that(
                 expired_tokens,

--- a/integration_tests/suite/test_external_auth.py
+++ b/integration_tests/suite/test_external_auth.py
@@ -298,7 +298,7 @@ class TestExternalAuthConfigAPI(base.WazoAuthTestCase):
         )
 
     def test_given_mastertenant_with_config_and_subtenant_when_subtenant_get_config_then_not_found(
-        self
+        self,
     ):
         self.client.external.create_config(
             auth_type=self.EXTERNAL_AUTH_TYPE, data=self.SECRET
@@ -314,7 +314,7 @@ class TestExternalAuthConfigAPI(base.WazoAuthTestCase):
             )
 
     def test_given_mastertenant_and_subtenant_with_config_when_mastertenant_get_config_then_ok(
-        self
+        self,
     ):
         with self.client_in_subtenant(parent_uuid=self.top_tenant_uuid) as (
             client,

--- a/wazo_auth/bootstrap.py
+++ b/wazo_auth/bootstrap.py
@@ -87,10 +87,10 @@ def complete():
     wazo_auth_config = read_config_file_hierarchy(
         {'config_file': DEFAULT_WAZO_AUTH_CONFIG_FILE}
     )
-    port = wazo_auth_config['rest_api']['https']['port']
+    port = wazo_auth_config['rest_api']['port']
     https = (
-        wazo_auth_config['rest_api']['https']['certificate']
-        and wazo_auth_config['rest_api']['https']['private_key']
+        wazo_auth_config['rest_api']['certificate']
+        and wazo_auth_config['rest_api']['private_key']
     )
     scheme = 'https' if https else 'http'
     url = URL.format(scheme, port)

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -71,12 +71,10 @@ _DEFAULT_CONFIG = {
     },
     'rest_api': {
         'max_threads': 25,
-        'https': {
-            'listen': '0.0.0.0',
-            'port': _DEFAULT_HTTP_PORT,
-            'certificate': '/usr/share/xivo-certs/server.crt',
-            'private_key': '/usr/share/xivo-certs/server.key',
-        },
+        'listen': '0.0.0.0',
+        'port': _DEFAULT_HTTP_PORT,
+        'certificate': '/usr/share/xivo-certs/server.crt',
+        'private_key': '/usr/share/xivo-certs/server.key',
         'cors': {
             'enabled': True,
             'allow_headers': [

--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -45,7 +45,7 @@ class Controller:
             config['consul'],
             config['service_discovery'],
             config['amqp'],
-            partial(self_check, config['rest_api']['https']['port']),
+            partial(self_check, config['rest_api']['port']),
         ]
 
         template_formatter = services.helpers.TemplateFormatter(config)

--- a/wazo_auth/http_server.py
+++ b/wazo_auth/http_server.py
@@ -67,7 +67,7 @@ class CoreRestApi:
             CORS(app, **cors_config)
 
     def run(self):
-        bind_addr = (self.config['https']['listen'], self.config['https']['port'])
+        bind_addr = (self.config['listen'], self.config['port'])
 
         wsgi_app = wsgi.WSGIPathInfoDispatcher({'/': app})
         self.server = wsgi.WSGIServer(
@@ -75,9 +75,9 @@ class CoreRestApi:
             wsgi_app=wsgi_app,
             numthreads=self.config['max_threads'],
         )
-        if self.config['https']['certificate'] and self.config['https']['private_key']:
+        if self.config['certificate'] and self.config['private_key']:
             self.server.ssl_adapter = http_helpers.ssl_adapter(
-                self.config['https']['certificate'], self.config['https']['private_key']
+                self.config['certificate'], self.config['private_key']
             )
         logger.debug(
             'WSGIServer starting... uid: %s, listen: %s:%s',


### PR DESCRIPTION
config: move rest_api/https to rest_api
Fix bootstrap when ssl is disabled