### PR TITLE
refresh token: do not publish create event when not created

### DIFF
--- a/wazo_auth/database/queries/refresh_token.py
+++ b/wazo_auth/database/queries/refresh_token.py
@@ -51,8 +51,8 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                     constraint = e.orig.diag.constraint_name
                     if constraint == 'auth_refresh_token_client_id_user_uuid':
                         session.rollback()
-                        return self._get_existing_refresh_token(
-                            session, body['client_id'], body['user_uuid']
+                        raise exceptions.DuplicatedRefreshTokenException(
+                            body['user_uuid'], body['client_id'],
                         )
                 raise
 
@@ -144,7 +144,7 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                 )
             return refresh_tokens
 
-    def _get_existing_refresh_token(self, session, client_id, user_uuid):
+    def get_existing_refresh_token(self, client_id, user_uuid):
         filter_ = and_(
             RefreshToken.client_id == client_id, RefreshToken.user_uuid == user_uuid
         )

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -274,6 +274,15 @@ class DuplicatePolicyException(TokenServiceException):
         return 'Policy "{}" already exists'.format(self._name)
 
 
+class DuplicatedRefreshTokenException(Exception):
+    def __init__(self, user_uuid, client_id):
+        self.client_id = client_id
+        self.user_uuid = user_uuid
+        super().__init__(
+            f'Duplicated Refresh Token for user_uuid {user_uuid} and client_id {client_id}',
+        )
+
+
 class DuplicateTemplateException(TokenServiceException):
 
     code = 409


### PR DESCRIPTION
If a refresh token is re-used instead of creating a new one the refresh token
created event is not published