### PR TITLE
use flush instead of commit to check integrity

### DIFF
--- a/wazo_auth/database/queries/address.py
+++ b/wazo_auth/database/queries/address.py
@@ -33,7 +33,7 @@ class AddressDAO(BaseDAO):
         address = Address(**kwargs)
         with self.new_session() as s:
             s.add(address)
-            s.commit()
+            s.flush()
             return address.id_
 
     def update(self, address_id, **kwargs):

--- a/wazo_auth/database/queries/external_auth.py
+++ b/wazo_auth/database/queries/external_auth.py
@@ -42,7 +42,7 @@ class ExternalAuthDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             external_type = self._find_or_create_type(s, auth_type)
             external_data = ExternalAuthData(data=serialized_data)
             s.add(external_data)
-            s.commit()
+            s.flush()
             user_external_auth = UserExternalAuth(
                 user_uuid=str(user_uuid),
                 external_auth_type_uuid=external_type.uuid,
@@ -50,7 +50,7 @@ class ExternalAuthDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             )
             s.add(user_external_auth)
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode in (
                     self._UNIQUE_CONSTRAINT_CODE,
@@ -71,7 +71,7 @@ class ExternalAuthDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             external_data = ExternalAuthData(data=data)
             self._assert_tenant_exists(s, tenant_uuid)
             s.add(external_data)
-            s.commit()
+            s.flush()
             external_auth_config = ExternalAuthConfig(
                 data_uuid=external_data.uuid,
                 tenant_uuid=tenant_uuid,
@@ -79,7 +79,7 @@ class ExternalAuthDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             )
             s.add(external_auth_config)
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode in (self._UNIQUE_CONSTRAINT_CODE):
                     constraint = e.orig.diag.constraint_name

--- a/wazo_auth/database/queries/group.py
+++ b/wazo_auth/database/queries/group.py
@@ -22,7 +22,7 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         with self.new_session() as s:
             s.add(group_policy)
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     # This association already exists.
@@ -41,7 +41,7 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         with self.new_session() as s:
             s.add(user_group)
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     # This association already exists.
@@ -109,7 +109,7 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         with self.new_session() as s:
             s.add(group)
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     column = self.constraint_to_column_map.get(
@@ -171,7 +171,7 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                 if not affected_rows:
                     raise exceptions.UnknownGroupException(group_uuid)
 
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     column = self.constraint_to_column_map.get(

--- a/wazo_auth/database/queries/policy.py
+++ b/wazo_auth/database/queries/policy.py
@@ -29,7 +29,7 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         with self.new_session() as s:
             self._associate_acl_templates(s, policy_uuid, [acl_template])
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     raise exceptions.DuplicateTemplateException(acl_template)
@@ -84,7 +84,7 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         with self.new_session() as s:
             s.add(policy)
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     raise exceptions.DuplicatePolicyException(name)
@@ -189,7 +189,7 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                 raise exceptions.UnknownPolicyException(policy_uuid)
 
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     raise exceptions.DuplicatePolicyException(name)
@@ -225,7 +225,7 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
     def _insert_acl_template(self, s, template):
         tpl = ACLTemplate(template=template)
         s.add(tpl)
-        s.commit()
+        s.flush()
         return tpl.id_
 
     def _policy_exists(self, s, policy_uuid, tenant_uuids=None):

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -77,7 +77,7 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         with self.new_session() as s:
             s.add(tenant)
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     column = self.constraint_to_column_map.get(

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -34,7 +34,7 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         with self.new_session() as s:
             s.add(user_policy)
             try:
-                s.commit()
+                s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     # This association already exists.
@@ -171,7 +171,7 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                         user_uuid=user.uuid, email_uuid=email.uuid, main=True
                     )
                     s.add(user_email)
-                    s.commit()
+                    s.flush()
             except exc.IntegrityError as e:
                 if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                     column = self.constraint_to_column_map.get(


### PR DESCRIPTION
reason: When there are intermediate commits, we cannot rollback on error
and it can cause weird behaviour