### PR TITLE
Wazo 1609 request bound sessions

### DIFF
--- a/integration_tests/suite/database/test_db_email.py
+++ b/integration_tests/suite/database/test_db_email.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -26,8 +26,8 @@ class TestEmailDAO(base.DAOTestCase):
         assert_that(self.is_email_confirmed(email_uuid), equal_to(True))
 
     def is_email_confirmed(self, email_uuid):
-        with self._email_dao.new_session() as s:
-            emails = s.query(models.Email).filter(models.Email.uuid == str(email_uuid))
-            for email in emails.all():
-                return email.confirmed
+        s = self.session
+        emails = s.query(models.Email).filter(models.Email.uuid == str(email_uuid))
+        for email in emails.all():
+            return email.confirmed
         return False

--- a/integration_tests/suite/database/test_db_email.py
+++ b/integration_tests/suite/database/test_db_email.py
@@ -26,8 +26,9 @@ class TestEmailDAO(base.DAOTestCase):
         assert_that(self.is_email_confirmed(email_uuid), equal_to(True))
 
     def is_email_confirmed(self, email_uuid):
-        s = self.session
-        emails = s.query(models.Email).filter(models.Email.uuid == str(email_uuid))
+        emails = self.session.query(models.Email).filter(
+            models.Email.uuid == str(email_uuid)
+        )
         for email in emails.all():
             return email.confirmed
         return False

--- a/integration_tests/suite/database/test_db_external_auth.py
+++ b/integration_tests/suite/database/test_db_external_auth.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -95,9 +95,10 @@ class TestExternalAuthDAO(base.DAOTestCase):
             ),
         )
 
+    @fixtures.db.external_auth('foobarcrm')
     @fixtures.db.user()
     @fixtures.db.user()
-    def test_delete(self, user_1_uuid, user_2_uuid):
+    def test_delete(self, user_1_uuid, user_2_uuid, _):
         assert_that(
             calling(self._external_auth_dao.delete).with_args(
                 self.unknown_uuid, self.auth_type
@@ -172,9 +173,10 @@ class TestExternalAuthDAO(base.DAOTestCase):
         self._external_auth_dao.enable_all(auth_types)
         assert_enabled(auth_types)
 
+    @fixtures.db.external_auth('foobarcrm')
     @fixtures.db.user()
     @fixtures.db.user()
-    def test_get(self, user_1_uuid, user_2_uuid):
+    def test_get(self, user_1_uuid, user_2_uuid, _):
         assert_that(
             calling(self._external_auth_dao.get).with_args(
                 self.unknown_uuid, self.auth_type
@@ -263,8 +265,9 @@ class TestExternalAuthDAO(base.DAOTestCase):
         expected = [{'type': 'one', 'data': data_one, 'enabled': True}]
         assert_that(result, contains(*expected))
 
+    @fixtures.db.external_auth('foobarcrm')
     @fixtures.db.user()
-    def test_update(self, user_uuid):
+    def test_update(self, user_uuid, _):
         new_data = {'foo': 'bar'}
 
         assert_that(

--- a/integration_tests/suite/database/test_db_external_auth.py
+++ b/integration_tests/suite/database/test_db_external_auth.py
@@ -147,8 +147,7 @@ class TestExternalAuthDAO(base.DAOTestCase):
     @fixtures.db.user()
     def test_enable_all(self, user_uuid):
         def assert_enabled(enabled_types):
-            s = self.session
-            query = s.query(
+            query = self.session.query(
                 models.ExternalAuthType.name, models.ExternalAuthType.enabled
             )
             result = {r.name: r.enabled for r in query.all()}

--- a/integration_tests/suite/database/test_db_external_auth.py
+++ b/integration_tests/suite/database/test_db_external_auth.py
@@ -66,14 +66,15 @@ class TestExternalAuthDAO(base.DAOTestCase):
 
     @fixtures.db.user()
     def test_create(self, user_uuid):
-        assert_that(
-            calling(self._external_auth_dao.create).with_args(
-                self.unknown_uuid, self.auth_type, self.data
-            ),
-            raises(exceptions.UnknownUserException).matching(
-                has_properties(status_code=404, resource='users')
-            ),
-        )
+        with self.auto_rollback():
+            assert_that(
+                calling(self._external_auth_dao.create).with_args(
+                    self.unknown_uuid, self.auth_type, self.data
+                ),
+                raises(exceptions.UnknownUserException).matching(
+                    has_properties(status_code=404, resource='users')
+                ),
+            )
 
         result = self._external_auth_dao.create(user_uuid, self.auth_type, self.data)
         assert_that(result, equal_to(self.data))

--- a/integration_tests/suite/database/test_db_external_auth.py
+++ b/integration_tests/suite/database/test_db_external_auth.py
@@ -146,11 +146,11 @@ class TestExternalAuthDAO(base.DAOTestCase):
     @fixtures.db.user()
     def test_enable_all(self, user_uuid):
         def assert_enabled(enabled_types):
-            with self._external_auth_dao.new_session() as s:
-                query = s.query(
-                    models.ExternalAuthType.name, models.ExternalAuthType.enabled
-                )
-                result = {r.name: r.enabled for r in query.all()}
+            s = self.session
+            query = s.query(
+                models.ExternalAuthType.name, models.ExternalAuthType.enabled
+            )
+            result = {r.name: r.enabled for r in query.all()}
             expected = has_entries({t: True for t in enabled_types})
             assert_that(result, expected)
             nb_enabled = len([t for t, enabled in result.items() if enabled])

--- a/integration_tests/suite/database/test_db_group.py
+++ b/integration_tests/suite/database/test_db_group.py
@@ -99,9 +99,8 @@ class TestGroupDAO(base.DAOTestCase):
         name = 'foobar'
 
         assert_that(group_uuid, equal_to(ANY_UUID))
-        s = self.session
         filter_ = models.Group.uuid == group_uuid
-        group = s.query(models.Group).filter(filter_).first()
+        group = self.session.query(models.Group).filter(filter_).first()
         assert_that(group, has_properties(name=name, tenant_uuid=tenant_uuid))
 
         assert_that(

--- a/integration_tests/suite/database/test_db_group.py
+++ b/integration_tests/suite/database/test_db_group.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -99,10 +99,10 @@ class TestGroupDAO(base.DAOTestCase):
         name = 'foobar'
 
         assert_that(group_uuid, equal_to(ANY_UUID))
-        with self._group_dao.new_session() as s:
-            filter_ = models.Group.uuid == group_uuid
-            group = s.query(models.Group).filter(filter_).first()
-            assert_that(group, has_properties(name=name, tenant_uuid=tenant_uuid))
+        s = self.session
+        filter_ = models.Group.uuid == group_uuid
+        group = s.query(models.Group).filter(filter_).first()
+        assert_that(group, has_properties(name=name, tenant_uuid=tenant_uuid))
 
         assert_that(
             calling(self._group_dao.create).with_args(name, tenant_uuid),

--- a/integration_tests/suite/database/test_db_policy.py
+++ b/integration_tests/suite/database/test_db_policy.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -37,20 +37,24 @@ class TestPolicyDAO(base.DAOTestCase):
             self.get_policy(uuid), has_entries(acl_templates=contains_inanyorder('#'))
         )
 
-        assert_that(
-            calling(self._policy_dao.associate_policy_template).with_args(uuid, '#'),
-            raises(exceptions.DuplicateTemplateException),
-        )
+        with self.auto_rollback():
+            assert_that(
+                calling(self._policy_dao.associate_policy_template).with_args(
+                    uuid, '#'
+                ),
+                raises(exceptions.DuplicateTemplateException),
+            )
 
         self._policy_dao.dissociate_policy_template(uuid, '#')
         assert_that(self.get_policy(uuid), has_entries(acl_templates=empty()))
 
-        assert_that(
-            calling(self._policy_dao.associate_policy_template).with_args(
-                'unknown', '#'
-            ),
-            raises(exceptions.UnknownPolicyException),
-        )
+        with self.auto_rollback():
+            assert_that(
+                calling(self._policy_dao.associate_policy_template).with_args(
+                    'unknown', '#'
+                ),
+                raises(exceptions.UnknownPolicyException),
+            )
 
         assert_that(
             self._policy_dao.dissociate_policy_template('unknown', '#'), equal_to(0)

--- a/integration_tests/suite/database/test_db_tenant.py
+++ b/integration_tests/suite/database/test_db_tenant.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from uuid import uuid4
@@ -120,14 +120,14 @@ class TestTenantDAO(base.DAOTestCase):
 
     def _assert_tenant_matches(self, uuid, name, parent_uuid=ANY_UUID):
         assert_that(uuid, equal_to(ANY_UUID))
-        with self._tenant_dao.new_session() as s:
-            tenant = (
-                s.query(models.Tenant.name, models.Tenant.parent_uuid)
-                .filter(models.Tenant.uuid == uuid)
-                .first()
-            )
+        s = self._tenant_dao.session
+        tenant = (
+            s.query(models.Tenant.name, models.Tenant.parent_uuid)
+            .filter(models.Tenant.uuid == uuid)
+            .first()
+        )
 
-            assert_that(tenant, has_properties(name=name, parent_uuid=parent_uuid))
+        assert_that(tenant, has_properties(name=name, parent_uuid=parent_uuid))
 
     def _create_tenant(self, **kwargs):
         kwargs.setdefault('name', None)
@@ -137,9 +137,9 @@ class TestTenantDAO(base.DAOTestCase):
         return self._tenant_dao.create(**kwargs)
 
     def _top_tenant_uuid(self):
-        with self._tenant_dao.new_session() as s:
-            return (
-                s.query(models.Tenant.uuid)
-                .filter(models.Tenant.uuid == models.Tenant.parent_uuid)
-                .scalar()
-            )
+        s = self.session
+        return (
+            s.query(models.Tenant.uuid)
+            .filter(models.Tenant.uuid == models.Tenant.parent_uuid)
+            .scalar()
+        )

--- a/integration_tests/suite/database/test_db_tenant.py
+++ b/integration_tests/suite/database/test_db_tenant.py
@@ -137,9 +137,8 @@ class TestTenantDAO(base.DAOTestCase):
         return self._tenant_dao.create(**kwargs)
 
     def _top_tenant_uuid(self):
-        s = self.session
         return (
-            s.query(models.Tenant.uuid)
+            self.session.query(models.Tenant.uuid)
             .filter(models.Tenant.uuid == models.Tenant.parent_uuid)
             .scalar()
         )

--- a/integration_tests/suite/database/test_db_token.py
+++ b/integration_tests/suite/database/test_db_token.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -69,46 +69,46 @@ class TestTokenDAO(base.DAOTestCase):
     @fixtures.db.token(expiration=0)
     @fixtures.db.token()
     def test_delete_expired_tokens_and_sessions(self, token_1, token_2, token_3):
-        with self._session_dao.new_session() as s:
-            (
-                expired_tokens,
-                expired_sessions,
-            ) = self._token_dao.delete_expired_tokens_and_sessions()
+        s = self.session
+        (
+            expired_tokens,
+            expired_sessions,
+        ) = self._token_dao.delete_expired_tokens_and_sessions()
 
-            assert_that(
-                expired_tokens,
-                all_of(
-                    not_(has_items(has_entries(uuid=token_1['uuid']))),
-                    has_items(has_entries(uuid=token_2['uuid'])),
-                    has_items(has_entries(uuid=token_3['uuid'])),
-                ),
-            )
+        assert_that(
+            expired_tokens,
+            all_of(
+                not_(has_items(has_entries(uuid=token_1['uuid']))),
+                has_items(has_entries(uuid=token_2['uuid'])),
+                has_items(has_entries(uuid=token_3['uuid'])),
+            ),
+        )
 
-            assert_that(
-                expired_sessions,
-                all_of(
-                    not_(has_items(has_entries(uuid=token_1['session_uuid']))),
-                    has_items(has_entries(uuid=token_2['session_uuid'])),
-                    has_items(has_entries(uuid=token_3['session_uuid'])),
-                ),
-            )
+        assert_that(
+            expired_sessions,
+            all_of(
+                not_(has_items(has_entries(uuid=token_1['session_uuid']))),
+                has_items(has_entries(uuid=token_2['session_uuid'])),
+                has_items(has_entries(uuid=token_3['session_uuid'])),
+            ),
+        )
 
-            sessions = s.query(models.Session).all()
-            assert_that(
-                sessions,
-                all_of(
-                    has_items(has_properties(uuid=token_1['session_uuid'])),
-                    not_(has_items(has_properties(uuid=token_2['session_uuid']))),
-                    not_(has_items(has_properties(uuid=token_3['session_uuid']))),
-                ),
-            )
+        sessions = s.query(models.Session).all()
+        assert_that(
+            sessions,
+            all_of(
+                has_items(has_properties(uuid=token_1['session_uuid'])),
+                not_(has_items(has_properties(uuid=token_2['session_uuid']))),
+                not_(has_items(has_properties(uuid=token_3['session_uuid']))),
+            ),
+        )
 
-            tokens = s.query(models.Token).all()
-            assert_that(
-                tokens,
-                all_of(
-                    has_items(has_properties(uuid=token_1['uuid'])),
-                    not_(has_items(has_properties(uuid=token_2['uuid']))),
-                    not_(has_items(has_properties(uuid=token_3['uuid']))),
-                ),
-            )
+        tokens = s.query(models.Token).all()
+        assert_that(
+            tokens,
+            all_of(
+                has_items(has_properties(uuid=token_1['uuid'])),
+                not_(has_items(has_properties(uuid=token_2['uuid']))),
+                not_(has_items(has_properties(uuid=token_3['uuid']))),
+            ),
+        )

--- a/integration_tests/suite/database/test_db_token.py
+++ b/integration_tests/suite/database/test_db_token.py
@@ -69,7 +69,6 @@ class TestTokenDAO(base.DAOTestCase):
     @fixtures.db.token(expiration=0)
     @fixtures.db.token()
     def test_delete_expired_tokens_and_sessions(self, token_1, token_2, token_3):
-        s = self.session
         (
             expired_tokens,
             expired_sessions,
@@ -93,7 +92,7 @@ class TestTokenDAO(base.DAOTestCase):
             ),
         )
 
-        sessions = s.query(models.Session).all()
+        sessions = self.session.query(models.Session).all()
         assert_that(
             sessions,
             all_of(
@@ -103,7 +102,7 @@ class TestTokenDAO(base.DAOTestCase):
             ),
         )
 
-        tokens = s.query(models.Token).all()
+        tokens = self.session.query(models.Token).all()
         assert_that(
             tokens,
             all_of(

--- a/integration_tests/suite/database/test_db_user.py
+++ b/integration_tests/suite/database/test_db_user.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -124,19 +124,19 @@ class TestUserDAO(base.DAOTestCase):
     @fixtures.db.user()
     def test_user_policy_association(self, user_uuid, policy_uuid):
         self._user_dao.add_policy(user_uuid, policy_uuid)
-        with self._user_dao.new_session() as s:
-            count = (
-                s.query(func.count(models.UserPolicy.user_uuid))
-                .filter(
-                    and_(
-                        models.UserPolicy.user_uuid == user_uuid,
-                        models.UserPolicy.policy_uuid == policy_uuid,
-                    )
+        s = self.session
+        count = (
+            s.query(func.count(models.UserPolicy.user_uuid))
+            .filter(
+                and_(
+                    models.UserPolicy.user_uuid == user_uuid,
+                    models.UserPolicy.policy_uuid == policy_uuid,
                 )
-                .scalar()
             )
+            .scalar()
+        )
 
-            assert_that(count, equal_to(1))
+        assert_that(count, equal_to(1))
 
         assert_that(
             calling(self._user_dao.add_policy).with_args(user_uuid, policy_uuid),
@@ -592,5 +592,5 @@ class TestUserDAO(base.DAOTestCase):
 
     def _email_exists(self, address):
         filter_ = models.Email.address == address
-        with self._user_dao.new_session() as s:
-            return s.query(func.count(models.Email.uuid)).filter(filter_).scalar() > 0
+        s = self.session
+        return s.query(func.count(models.Email.uuid)).filter(filter_).scalar() > 0

--- a/integration_tests/suite/database/test_db_user.py
+++ b/integration_tests/suite/database/test_db_user.py
@@ -124,9 +124,8 @@ class TestUserDAO(base.DAOTestCase):
     @fixtures.db.user()
     def test_user_policy_association(self, user_uuid, policy_uuid):
         self._user_dao.add_policy(user_uuid, policy_uuid)
-        s = self.session
         count = (
-            s.query(func.count(models.UserPolicy.user_uuid))
+            self.session.query(func.count(models.UserPolicy.user_uuid))
             .filter(
                 and_(
                     models.UserPolicy.user_uuid == user_uuid,
@@ -587,5 +586,7 @@ class TestUserDAO(base.DAOTestCase):
 
     def _email_exists(self, address):
         filter_ = models.Email.address == address
-        s = self.session
-        return s.query(func.count(models.Email.uuid)).filter(filter_).scalar() > 0
+        return (
+            self.session.query(func.count(models.Email.uuid)).filter(filter_).scalar()
+            > 0
+        )

--- a/integration_tests/suite/database/test_db_user.py
+++ b/integration_tests/suite/database/test_db_user.py
@@ -226,41 +226,36 @@ class TestUserDAO(base.DAOTestCase):
             purpose='user',
         )['uuid']
 
-        try:
-            assert_that(user_uuid, equal_to(ANY_UUID))
-            result = self._user_dao.list_(uuid=user_uuid)
-            assert_that(
-                result,
-                contains(
-                    has_entries(
-                        username=username,
-                        emails=contains(
-                            has_entries(
-                                address=email_address, confirmed=False, main=True
-                            )
-                        ),
-                    )
-                ),
-            )
-            assert_that(
-                calling(self._user_dao.create).with_args(
-                    'foo',
-                    uuid=user_uuid,
-                    email_address='foo@bar.baz',
-                    tenant_uuid=self.top_tenant_uuid,
-                    hash_='',
-                    salt=b'',
-                    purpose='user',
-                ),
-                raises(
-                    exceptions.ConflictException,
-                    has_properties(
-                        status_code=409, resource='users', details=has_entries(uuid=ANY)
+        assert_that(user_uuid, equal_to(ANY_UUID))
+        result = self._user_dao.list_(uuid=user_uuid)
+        assert_that(
+            result,
+            contains(
+                has_entries(
+                    username=username,
+                    emails=contains(
+                        has_entries(address=email_address, confirmed=False, main=True)
                     ),
+                )
+            ),
+        )
+        assert_that(
+            calling(self._user_dao.create).with_args(
+                'foo',
+                uuid=user_uuid,
+                email_address='foo@bar.baz',
+                tenant_uuid=self.top_tenant_uuid,
+                hash_='',
+                salt=b'',
+                purpose='user',
+            ),
+            raises(
+                exceptions.ConflictException,
+                has_properties(
+                    status_code=409, resource='users', details=has_entries(uuid=ANY)
                 ),
-            )
-        finally:
-            self._user_dao.delete(user_uuid)
+            ),
+        )
 
     def test_user_creation_email_confirmed(self):
         username = 'foobar'

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -84,6 +84,7 @@ class DAOTestCase(unittest.TestCase):
     unknown_uuid = '00000000-0000-0000-0000-000000000000'
 
     def setUp(self):
+        self.Session = helpers.Session
         self._address_dao = queries.AddressDAO()
         self._email_dao = queries.EmailDAO()
         self._external_auth_dao = queries.ExternalAuthDAO()
@@ -96,6 +97,10 @@ class DAOTestCase(unittest.TestCase):
         self._session_dao = session.SessionDAO()
 
         self.top_tenant_uuid = self._tenant_dao.find_top_tenant()
+
+    @property
+    def session(self):
+        return helpers.get_db_session()
 
 
 class AuthLaunchingTestCase(AssetLaunchingTestCase):

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -104,6 +104,13 @@ class DAOTestCase(unittest.TestCase):
         self.session.rollback()
         helpers.Session.remove()
 
+    @contextmanager
+    def auto_rollback(self):
+        try:
+            yield
+        finally:
+            self.session.rollback()
+
     @property
     def session(self):
         return helpers.get_db_session()

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -102,6 +102,7 @@ class DAOTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.session.rollback()
+        helpers.Session.remove()
 
     @property
     def session(self):

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -97,6 +97,11 @@ class DAOTestCase(unittest.TestCase):
         self._session_dao = session.SessionDAO()
 
         self.top_tenant_uuid = self._tenant_dao.find_top_tenant()
+
+        self.session.begin_nested()
+
+    def tearDown(self):
+        self.session.rollback()
 
     @property
     def session(self):

--- a/integration_tests/suite/helpers/fixtures/db.py
+++ b/integration_tests/suite/helpers/fixtures/db.py
@@ -31,7 +31,9 @@ def email(**email_args):
                 return decorated(self, email_uuid, *args, **kwargs)
             finally:
                 self.session.rollback()
+
         return wrapper
+
     return decorator
 
 
@@ -45,7 +47,9 @@ def external_auth(*auth_types):
                 return decorated(self, auth_types, *args, **kwargs)
             finally:
                 self.session.rollback()
+
         return wrapper
+
     return decorator
 
 
@@ -75,7 +79,9 @@ def token(**token_args):
                 return decorated(self, token, *args, **kwargs)
             finally:
                 self.session.rollback()
+
         return wrapper
+
     return decorator
 
 
@@ -92,7 +98,9 @@ def group(**group_args):
                 return decorated(self, group_uuid, *args, **kwargs)
             finally:
                 self.session.rollback()
+
         return wrapper
+
     return decorator
 
 
@@ -111,7 +119,9 @@ def policy(**policy_args):
                 return decorated(self, policy_uuid, *args, **kwargs)
             finally:
                 self.session.rollback()
+
         return wrapper
+
     return decorator
 
 
@@ -131,7 +141,9 @@ def tenant(**tenant_args):
                 return decorated(self, tenant_uuid, *args, **kwargs)
             finally:
                 self.session.rollback()
+
         return wrapper
+
     return decorator
 
 
@@ -155,7 +167,9 @@ def user(**user_args):
                 return decorated(self, user_uuid, *args, **kwargs)
             finally:
                 self.session.rollback()
+
         return wrapper
+
     return decorator
 
 
@@ -169,5 +183,7 @@ def refresh_token(**refresh_token_args):
                 return decorated(self, refresh_token, *args, **kwargs)
             finally:
                 self.session.rollback()
+
         return wrapper
+
     return decorator

--- a/integration_tests/suite/helpers/fixtures/db.py
+++ b/integration_tests/suite/helpers/fixtures/db.py
@@ -9,9 +9,6 @@ import uuid
 
 from functools import wraps
 
-from wazo_auth import exceptions
-from wazo_auth.database import models
-
 
 A_SALT = os.urandom(64)
 
@@ -29,17 +26,12 @@ def email(**email_args):
         @wraps(decorated)
         def wrapper(self, *args, **kwargs):
             email_uuid = self._email_dao.create(**email_args)
+            self.session.begin_nested()
             try:
-                result = decorated(self, email_uuid, *args, **kwargs)
+                return decorated(self, email_uuid, *args, **kwargs)
             finally:
-                try:
-                    self._email_dao.delete(email_uuid)
-                except exceptions.UnknownEmailException:
-                    pass
-            return result
-
+                self.session.rollback()
         return wrapper
-
     return decorator
 
 
@@ -48,14 +40,12 @@ def external_auth(*auth_types):
         @wraps(decorated)
         def wrapper(self, *args, **kwargs):
             self._external_auth_dao.enable_all(auth_types)
+            self.session.begin_nested()
             try:
-                result = decorated(self, auth_types, *args, **kwargs)
+                return decorated(self, auth_types, *args, **kwargs)
             finally:
-                self._external_auth_dao.enable_all([])
-            return result
-
+                self.session.rollback()
         return wrapper
-
     return decorator
 
 
@@ -80,18 +70,12 @@ def token(**token_args):
             token_uuid, session_uuid = self._token_dao.create(token, session)
             token['uuid'] = token_uuid
             token['session_uuid'] = session_uuid
+            self.session.begin_nested()
             try:
-                result = decorated(self, token, *args, **kwargs)
+                return decorated(self, token, *args, **kwargs)
             finally:
-                self._token_dao.delete(token_uuid)
-                s = self._session_dao.session
-                s.query(models.Session).filter(
-                    models.Session.uuid == session_uuid
-                ).delete()
-            return result
-
+                self.session.rollback()
         return wrapper
-
     return decorator
 
 
@@ -103,17 +87,12 @@ def group(**group_args):
         def wrapper(self, *args, **kwargs):
             group_args.setdefault('tenant_uuid', self.top_tenant_uuid)
             group_uuid = self._group_dao.create(**group_args)
+            self.session.begin_nested()
             try:
-                result = decorated(self, group_uuid, *args, **kwargs)
+                return decorated(self, group_uuid, *args, **kwargs)
             finally:
-                try:
-                    self._group_dao.delete(group_uuid)
-                except exceptions.UnknownGroupException:
-                    pass
-            return result
-
+                self.session.rollback()
         return wrapper
-
     return decorator
 
 
@@ -127,17 +106,12 @@ def policy(**policy_args):
         def wrapper(self, *args, **kwargs):
             policy_args.setdefault('tenant_uuid', self.top_tenant_uuid)
             policy_uuid = self._policy_dao.create(**policy_args)
+            self.session.begin_nested()
             try:
-                result = decorated(self, policy_uuid, *args, **kwargs)
+                return decorated(self, policy_uuid, *args, **kwargs)
             finally:
-                try:
-                    self._policy_dao.delete(policy_uuid, [policy_args['tenant_uuid']])
-                except exceptions.UnknownPolicyException:
-                    pass
-            return result
-
+                self.session.rollback()
         return wrapper
-
     return decorator
 
 
@@ -152,17 +126,12 @@ def tenant(**tenant_args):
             tenant_args.setdefault('parent_uuid', self.top_tenant_uuid)
 
             tenant_uuid = self._tenant_dao.create(**tenant_args)
+            self.session.begin_nested()
             try:
-                result = decorated(self, tenant_uuid, *args, **kwargs)
+                return decorated(self, tenant_uuid, *args, **kwargs)
             finally:
-                try:
-                    self._tenant_dao.delete(tenant_uuid)
-                except exceptions.UnknownTenantException:
-                    pass
-            return result
-
+                self.session.rollback()
         return wrapper
-
     return decorator
 
 
@@ -181,17 +150,12 @@ def user(**user_args):
         def wrapper(self, *args, **kwargs):
             user_args.setdefault('tenant_uuid', self.top_tenant_uuid)
             user_uuid = self._user_dao.create(**user_args)['uuid']
+            self.session.begin_nested()
             try:
-                result = decorated(self, user_uuid, *args, **kwargs)
+                return decorated(self, user_uuid, *args, **kwargs)
             finally:
-                try:
-                    self._user_dao.delete(user_uuid)
-                except exceptions.UnknownUserException:
-                    pass
-            return result
-
+                self.session.rollback()
         return wrapper
-
     return decorator
 
 
@@ -200,13 +164,10 @@ def refresh_token(**refresh_token_args):
         @wraps(decorated)
         def wrapper(self, *args, **kwargs):
             refresh_token = self._refresh_token_dao.create(refresh_token_args)
+            self.session.begin_nested()
             try:
-                result = decorated(self, refresh_token, *args, **kwargs)
+                return decorated(self, refresh_token, *args, **kwargs)
             finally:
-                # TODO(pcm): remove the refresh token when delete gets implemented
-                pass
-            return result
-
+                self.session.rollback()
         return wrapper
-
     return decorator

--- a/integration_tests/suite/helpers/fixtures/db.py
+++ b/integration_tests/suite/helpers/fixtures/db.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -84,10 +84,10 @@ def token(**token_args):
                 result = decorated(self, token, *args, **kwargs)
             finally:
                 self._token_dao.delete(token_uuid)
-                with self._session_dao.new_session() as s:
-                    s.query(models.Session).filter(
-                        models.Session.uuid == session_uuid
-                    ).delete()
+                s = self._session_dao.session
+                s.query(models.Session).filter(
+                    models.Session.uuid == session_uuid
+                ).delete()
             return result
 
         return wrapper

--- a/integration_tests/suite/test_auth_microsoft.py
+++ b/integration_tests/suite/test_auth_microsoft.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -23,13 +23,13 @@ from xivo_test_helpers.hamcrest.raises import raises
 from wazo_auth import bootstrap
 from wazo_auth.database import helpers
 
-from .helpers.base import BaseTestCase
+from .helpers.base import BaseTestCase as _BaseTestCase
 
 MICROSOFT = 'microsoft'
 AUTHORIZE_URL = 'http://localhost:{port}/microsoft/authorize/{state}'
 
 
-class BaseTestCase(BaseTestCase):
+class BaseTestCase(_BaseTestCase):
 
     username = 'mario'
     password = 'mario'

--- a/integration_tests/suite/test_external_auth.py
+++ b/integration_tests/suite/test_external_auth.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -190,13 +190,14 @@ class TestExternalAuthAPI(base.WazoAuthTestCase):
 
         def oauth2_is_done():
             try:
-                return self.client.external.get('foo', user['uuid'])
+                assert_that(
+                    self.client.external.get('foo', user['uuid']),
+                    has_entries(access_token=token),
+                )
             except requests.HTTPError:
-                return False
+                assert False
 
-        data = until.true(oauth2_is_done, timeout=5, interval=0.25)
-
-        assert_that(data, has_entries(access_token=token))
+        until.assert_(oauth2_is_done, timeout=5, interval=0.25)
 
         def bus_received_msg():
             assert_that(

--- a/integration_tests/suite/test_external_auth.py
+++ b/integration_tests/suite/test_external_auth.py
@@ -195,7 +195,7 @@ class TestExternalAuthAPI(base.WazoAuthTestCase):
                     has_entries(access_token=token),
                 )
             except requests.HTTPError:
-                assert False
+                assert_that(False)
 
         until.assert_(oauth2_is_done, timeout=5, interval=0.25)
 

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -250,16 +250,14 @@ class TestCore(WazoAuthTestCase):
         assert_that(self._is_valid(token))
 
     def _is_token_in_the_db(self, token):
-        s = self.session
+        s = helpers.get_db_session()
         result = s.query(models.Token).filter(models.Token.uuid == token).first()
         return True if result else False
 
     def _is_session_in_the_db(self, session_uuid):
-        s = self.session
+        s = helpers.get_db_session()
         result = (
-            s.query(models.Session)
-            .filter(models.Session.uuid == session_uuid)
-            .first()
+            s.query(models.Session).filter(models.Session.uuid == session_uuid).first()
         )
         return True if result else False
 

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -250,18 +250,18 @@ class TestCore(WazoAuthTestCase):
         assert_that(self._is_valid(token))
 
     def _is_token_in_the_db(self, token):
-        with helpers.new_session() as s:
-            result = s.query(models.Token).filter(models.Token.uuid == token).first()
-            return True if result else False
+        s = self.session
+        result = s.query(models.Token).filter(models.Token.uuid == token).first()
+        return True if result else False
 
     def _is_session_in_the_db(self, session_uuid):
-        with helpers.new_session() as s:
-            result = (
-                s.query(models.Session)
-                .filter(models.Session.uuid == session_uuid)
-                .first()
-            )
-            return True if result else False
+        s = self.session
+        result = (
+            s.query(models.Session)
+            .filter(models.Session.uuid == session_uuid)
+            .first()
+        )
+        return True if result else False
 
 
 class TestNoSSLCertificate(AuthLaunchingTestCase):

--- a/wazo_auth/bootstrap.py
+++ b/wazo_auth/bootstrap.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -12,7 +12,7 @@ from xivo.config_helper import parse_config_file, read_config_file_hierarchy
 
 from wazo_auth import services
 from wazo_auth.database import queries
-from wazo_auth.database.helpers import init_db
+from wazo_auth.database.helpers import init_db, Session
 
 from pwd import getpwnam
 
@@ -120,6 +120,10 @@ def create_initial_user(db_uri, username, password, purpose, policy_name):
             )
             policy_uuid = policy_service.list(name=policy_name)[0]['uuid']
             user_service.add_policy(user['uuid'], policy_uuid)
+    try:
+        Session.commit()
+    finally:
+        Session.close()
 
 
 def complete():

--- a/wazo_auth/bootstrap.py
+++ b/wazo_auth/bootstrap.py
@@ -12,7 +12,7 @@ from xivo.config_helper import parse_config_file, read_config_file_hierarchy
 
 from wazo_auth import services
 from wazo_auth.database import queries
-from wazo_auth.database.helpers import init_db, Session
+from wazo_auth.database.helpers import init_db, commit_or_rollback
 
 from pwd import getpwnam
 
@@ -120,10 +120,7 @@ def create_initial_user(db_uri, username, password, purpose, policy_name):
             )
             policy_uuid = policy_service.list(name=policy_name)[0]['uuid']
             user_service.add_policy(user['uuid'], policy_uuid)
-    try:
-        Session.commit()
-    finally:
-        Session.close()
+    commit_or_rollback()
 
 
 def complete():

--- a/wazo_auth/database/helpers.py
+++ b/wazo_auth/database/helpers.py
@@ -27,5 +27,6 @@ def commit_or_rollback():
         Session.commit()
     except Exception:
         Session.rollback()
+        raise
     finally:
         Session.close()

--- a/wazo_auth/database/helpers.py
+++ b/wazo_auth/database/helpers.py
@@ -20,3 +20,12 @@ def deinit_db():
 
 def get_db_session():
     return Session()
+
+
+def commit_or_rollback():
+    try:
+        Session.commit()
+    except Exception:
+        Session.rollback()
+    finally:
+        Session.close()

--- a/wazo_auth/database/helpers.py
+++ b/wazo_auth/database/helpers.py
@@ -1,7 +1,5 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-from contextlib import contextmanager
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
@@ -20,14 +18,5 @@ def deinit_db():
     Session.configure(bind=None)
 
 
-@contextmanager
-def new_session():
-    session = Session()
-    try:
-        yield session
-        session.commit()
-    except Exception:
-        session.rollback()
-        raise
-    finally:
-        session.close()
+def get_db_session():
+    return Session()

--- a/wazo_auth/database/queries/address.py
+++ b/wazo_auth/database/queries/address.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_auth import exceptions
@@ -9,20 +9,20 @@ from ..models import Address
 
 class AddressDAO(BaseDAO):
     def delete(self, address_id):
-        with self.new_session() as s:
-            s.query(Address).filter(Address.id_ == address_id).delete()
+        s = self.session
+        s.query(Address).filter(Address.id_ == address_id).delete()
 
     def get(self, address_id):
-        with self.new_session() as s:
-            for row in s.query(Address).filter(Address.id_ == address_id).all():
-                return dict(
-                    line_1=row.line_1,
-                    line_2=row.line_2,
-                    city=row.city,
-                    state=row.state,
-                    country=row.country,
-                    zip_code=row.zip_code,
-                )
+        s = self.session
+        for row in s.query(Address).filter(Address.id_ == address_id).all():
+            return dict(
+                line_1=row.line_1,
+                line_2=row.line_2,
+                city=row.city,
+                state=row.state,
+                country=row.country,
+                zip_code=row.zip_code,
+            )
 
         raise exceptions.UnknownAddressException(address_id)
 
@@ -31,18 +31,18 @@ class AddressDAO(BaseDAO):
             return None
 
         address = Address(**kwargs)
-        with self.new_session() as s:
-            s.add(address)
-            s.flush()
-            return address.id_
+        s = self.session
+        s.add(address)
+        s.flush()
+        return address.id_
 
     def update(self, address_id, **kwargs):
         if self._address_is_empty(**kwargs):
             self.delete(address_id)
             return None
 
-        with self.new_session() as s:
-            s.query(Address).filter(Address.id_ == address_id).update(kwargs)
+        s = self.session
+        s.query(Address).filter(Address.id_ == address_id).update(kwargs)
 
         return address_id
 

--- a/wazo_auth/database/queries/address.py
+++ b/wazo_auth/database/queries/address.py
@@ -10,6 +10,7 @@ from ..models import Address
 class AddressDAO(BaseDAO):
     def delete(self, address_id):
         self.session.query(Address).filter(Address.id_ == address_id).delete()
+        self.session.flush()
 
     def get(self, address_id):
         for row in self.session.query(Address).filter(Address.id_ == address_id).all():
@@ -36,10 +37,11 @@ class AddressDAO(BaseDAO):
     def update(self, address_id, **kwargs):
         if self._address_is_empty(**kwargs):
             self.delete(address_id)
+            self.session.flush()
             return None
 
         self.session.query(Address).filter(Address.id_ == address_id).update(kwargs)
-
+        self.session.flush()
         return address_id
 
     def _address_is_empty(self, **kwargs):

--- a/wazo_auth/database/queries/address.py
+++ b/wazo_auth/database/queries/address.py
@@ -9,12 +9,10 @@ from ..models import Address
 
 class AddressDAO(BaseDAO):
     def delete(self, address_id):
-        s = self.session
-        s.query(Address).filter(Address.id_ == address_id).delete()
+        self.session.query(Address).filter(Address.id_ == address_id).delete()
 
     def get(self, address_id):
-        s = self.session
-        for row in s.query(Address).filter(Address.id_ == address_id).all():
+        for row in self.session.query(Address).filter(Address.id_ == address_id).all():
             return dict(
                 line_1=row.line_1,
                 line_2=row.line_2,
@@ -31,9 +29,8 @@ class AddressDAO(BaseDAO):
             return None
 
         address = Address(**kwargs)
-        s = self.session
-        s.add(address)
-        s.flush()
+        self.session.add(address)
+        self.session.flush()
         return address.id_
 
     def update(self, address_id, **kwargs):
@@ -41,8 +38,7 @@ class AddressDAO(BaseDAO):
             self.delete(address_id)
             return None
 
-        s = self.session
-        s.query(Address).filter(Address.id_ == address_id).update(kwargs)
+        self.session.query(Address).filter(Address.id_ == address_id).update(kwargs)
 
         return address_id
 

--- a/wazo_auth/database/queries/base.py
+++ b/wazo_auth/database/queries/base.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .. import helpers
@@ -74,4 +74,6 @@ class BaseDAO:
     _UNIQUE_CONSTRAINT_CODE = '23505'
     _FKEY_CONSTRAINT_CODE = '23503'
 
-    new_session = staticmethod(helpers.new_session)
+    @property
+    def session(self):
+        return helpers.get_db_session()

--- a/wazo_auth/database/queries/email.py
+++ b/wazo_auth/database/queries/email.py
@@ -19,6 +19,7 @@ class EmailDAO(BaseDAO):
         nb_updated = (
             self.session.query(Email).filter(filter_).update({'confirmed': True})
         )
+        self.session.flush()
 
         if not nb_updated:
             raise exceptions.UnknownEmailException(email_uuid)
@@ -26,6 +27,7 @@ class EmailDAO(BaseDAO):
     def delete(self, email_uuid):
         filter_ = Email.uuid == str(email_uuid)
         nb_deleted = self.session.query(Email).filter(filter_).delete()
+        self.session.flush()
 
         if not nb_deleted:
             raise exceptions.UnknownEmailException(email_uuid)

--- a/wazo_auth/database/queries/email.py
+++ b/wazo_auth/database/queries/email.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_auth import exceptions
@@ -10,23 +10,23 @@ from ..models import Email
 class EmailDAO(BaseDAO):
     def create(self, address, confirmed=False):
         email = Email(address=address, confirmed=confirmed)
-        with self.new_session() as s:
-            s.add(email)
-            s.flush()
-            return email.uuid
+        s = self.session
+        s.add(email)
+        s.flush()
+        return email.uuid
 
     def confirm(self, email_uuid):
         filter_ = Email.uuid == str(email_uuid)
-        with self.new_session() as s:
-            nb_updated = s.query(Email).filter(filter_).update({'confirmed': True})
+        s = self.session
+        nb_updated = s.query(Email).filter(filter_).update({'confirmed': True})
 
-            if not nb_updated:
-                raise exceptions.UnknownEmailException(email_uuid)
+        if not nb_updated:
+            raise exceptions.UnknownEmailException(email_uuid)
 
     def delete(self, email_uuid):
         filter_ = Email.uuid == str(email_uuid)
-        with self.new_session() as s:
-            nb_deleted = s.query(Email).filter(filter_).delete()
+        s = self.session
+        nb_deleted = s.query(Email).filter(filter_).delete()
 
         if not nb_deleted:
             raise exceptions.UnknownEmailException(email_uuid)

--- a/wazo_auth/database/queries/email.py
+++ b/wazo_auth/database/queries/email.py
@@ -10,23 +10,22 @@ from ..models import Email
 class EmailDAO(BaseDAO):
     def create(self, address, confirmed=False):
         email = Email(address=address, confirmed=confirmed)
-        s = self.session
-        s.add(email)
-        s.flush()
+        self.session.add(email)
+        self.session.flush()
         return email.uuid
 
     def confirm(self, email_uuid):
         filter_ = Email.uuid == str(email_uuid)
-        s = self.session
-        nb_updated = s.query(Email).filter(filter_).update({'confirmed': True})
+        nb_updated = (
+            self.session.query(Email).filter(filter_).update({'confirmed': True})
+        )
 
         if not nb_updated:
             raise exceptions.UnknownEmailException(email_uuid)
 
     def delete(self, email_uuid):
         filter_ = Email.uuid == str(email_uuid)
-        s = self.session
-        nb_deleted = s.query(Email).filter(filter_).delete()
+        nb_deleted = self.session.query(Email).filter(filter_).delete()
 
         if not nb_deleted:
             raise exceptions.UnknownEmailException(email_uuid)

--- a/wazo_auth/database/queries/external_auth.py
+++ b/wazo_auth/database/queries/external_auth.py
@@ -46,12 +46,10 @@ class ExternalAuthDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             external_auth_type_uuid=external_type.uuid,
             external_auth_data_uuid=external_data.uuid,
         )
-        self.session.begin_nested()
         self.session.add(user_external_auth)
         try:
-            self.session.commit()
+            self.session.flush()
         except exc.IntegrityError as e:
-            self.session.rollback()
             if e.orig.pgcode in (
                 self._UNIQUE_CONSTRAINT_CODE,
                 self._FKEY_CONSTRAINT_CODE,
@@ -76,12 +74,10 @@ class ExternalAuthDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             tenant_uuid=tenant_uuid,
             type_uuid=external_type.uuid,
         )
-        self.session.begin_nested()
         self.session.add(external_auth_config)
         try:
-            self.session.commit()
+            self.session.flush()
         except exc.IntegrityError as e:
-            self.session.rollback()
             if e.orig.pgcode in (self._UNIQUE_CONSTRAINT_CODE):
                 constraint = e.orig.diag.constraint_name
                 if constraint == 'auth_external_auth_config_pkey':

--- a/wazo_auth/database/queries/group.py
+++ b/wazo_auth/database/queries/group.py
@@ -127,6 +127,7 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             self.session.query(Group).filter(filter_).delete(synchronize_session=False)
         )
 
+        self.session.flush()
         if not nb_deleted:
             raise exceptions.UnknownGroupException(uuid)
 
@@ -180,7 +181,9 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             GroupPolicy.group_uuid == str(group_uuid),
         )
 
-        return self.session.query(GroupPolicy).filter(filter_).delete()
+        result = self.session.query(GroupPolicy).filter(filter_).delete()
+        self.session.flush()
+        return result
 
     def remove_user(self, group_uuid, user_uuid):
         filter_ = and_(
@@ -188,4 +191,6 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             UserGroup.group_uuid == str(group_uuid),
         )
 
-        return self.session.query(UserGroup).filter(filter_).delete()
+        result = self.session.query(UserGroup).filter(filter_).delete()
+        self.session.flush()
+        return result

--- a/wazo_auth/database/queries/policy.py
+++ b/wazo_auth/database/queries/policy.py
@@ -26,12 +26,10 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
     }
 
     def associate_policy_template(self, policy_uuid, acl_template):
-        self.session.begin_nested()
         self._associate_acl_templates(policy_uuid, [acl_template])
         try:
-            self.session.commit()
+            self.session.flush()
         except exc.IntegrityError as e:
-            self.session.rollback()
             if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                 raise exceptions.DuplicateTemplateException(acl_template)
             if e.orig.pgcode == self._FKEY_CONSTRAINT_CODE:

--- a/wazo_auth/database/queries/refresh_token.py
+++ b/wazo_auth/database/queries/refresh_token.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import and_, exc, text
@@ -37,26 +37,24 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             search_filter = self.new_search_filter(**search_params)
             filter_ = and_(filter_, strict_filter, search_filter)
 
-        with self.new_session() as session:
-            return session.query(RefreshToken).filter(filter_).count()
+        return self.session.query(RefreshToken).filter(filter_).count()
 
     def create(self, body):
         refresh_token = RefreshToken(**body)
-        with self.new_session() as session:
-            session.add(refresh_token)
-            try:
-                session.flush()
-            except exc.IntegrityError as e:
-                if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
-                    constraint = e.orig.diag.constraint_name
-                    if constraint == 'auth_refresh_token_client_id_user_uuid':
-                        session.rollback()
-                        raise exceptions.DuplicatedRefreshTokenException(
-                            body['user_uuid'], body['client_id'],
-                        )
-                raise
+        self.session.add(refresh_token)
+        try:
+            self.session.flush()
+        except exc.IntegrityError as e:
+            if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
+                constraint = e.orig.diag.constraint_name
+                if constraint == 'auth_refresh_token_client_id_user_uuid':
+                    self.session.rollback()
+                    raise exceptions.DuplicatedRefreshTokenException(
+                        body['user_uuid'], body['client_id'],
+                    )
+            raise
 
-            return refresh_token.uuid
+        return refresh_token.uuid
 
     def delete(self, tenant_uuids, user_uuid, client_id):
         filter_ = and_(
@@ -65,29 +63,27 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             RefreshToken.tenant_uuid.in_(tenant_uuids),
         )
 
-        with self.new_session() as session:
-            nb_deleted = (
-                session.query(RefreshToken)
-                .filter(filter_)
-                .delete(synchronize_session=False)
-            )
+        nb_deleted = (
+            self.session.query(RefreshToken)
+            .filter(filter_)
+            .delete(synchronize_session=False)
+        )
 
-            if not nb_deleted:
-                raise exceptions.UnknownRefreshToken(client_id)
+        if not nb_deleted:
+            raise exceptions.UnknownRefreshToken(client_id)
 
     def get(self, refresh_token, client_id):
-        with self.new_session() as session:
-            filter_ = and_(
-                RefreshToken.client_id == client_id, RefreshToken.uuid == refresh_token
-            )
-            query = session.query(RefreshToken).filter(filter_)
-            for refresh_token in query.all():
-                return {
-                    'backend_name': refresh_token.backend,
-                    'login': refresh_token.login,
-                }
+        filter_ = and_(
+            RefreshToken.client_id == client_id, RefreshToken.uuid == refresh_token
+        )
+        query = self.session.query(RefreshToken).filter(filter_)
+        for refresh_token in query.all():
+            return {
+                'backend_name': refresh_token.backend,
+                'login': refresh_token.login,
+            }
 
-            raise exceptions.UnknownRefreshToken(client_id)
+        raise exceptions.UnknownRefreshToken(client_id)
 
     def get_by_user(self, tenant_uuids, user_uuid, client_id):
         filter_ = and_(
@@ -96,17 +92,16 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             RefreshToken.tenant_uuid.in_(tenant_uuids),
         )
 
-        with self.new_session() as session:
-            query = session.query(RefreshToken.tenant_uuid, RefreshToken.mobile).filter(
-                filter_
-            )
-            for refresh_token in query.all():
-                return {
-                    'tenant_uuid': refresh_token.tenant_uuid,
-                    'mobile': refresh_token.mobile,
-                }
+        query = self.session.query(RefreshToken.tenant_uuid, RefreshToken.mobile).filter(
+            filter_
+        )
+        for refresh_token in query.all():
+            return {
+                'tenant_uuid': refresh_token.tenant_uuid,
+                'mobile': refresh_token.mobile,
+            }
 
-            raise exceptions.UnknownRefreshToken(client_id)
+        raise exceptions.UnknownRefreshToken(client_id)
 
     def list_(self, user_uuid=None, tenant_uuids=None, **search_params):
         filter_ = text('true')
@@ -124,31 +119,29 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         search_filter = self.new_search_filter(**search_params)
         filter_ = and_(filter_, strict_filter, search_filter)
 
-        with self.new_session() as session:
-            query = session.query(RefreshToken).filter(filter_)
-            query = self._paginator.update_query(query, **search_params)
+        query = self.session.query(RefreshToken).filter(filter_)
+        query = self._paginator.update_query(query, **search_params)
 
-            refresh_tokens = []
-            for refresh_token in query.all():
-                refresh_tokens.append(
-                    {
-                        'uuid': refresh_token.uuid,
-                        'user_uuid': refresh_token.user_uuid,
-                        'tenant_uuid': refresh_token.tenant_uuid,
-                        'client_id': refresh_token.client_id,
-                        'mobile': refresh_token.mobile,
-                        'created_at': refresh_token.created_at,
-                        'user_agent': refresh_token.user_agent,
-                        'remote_addr': refresh_token.remote_addr,
-                    }
-                )
-            return refresh_tokens
+        refresh_tokens = []
+        for refresh_token in query.all():
+            refresh_tokens.append(
+                {
+                    'uuid': refresh_token.uuid,
+                    'user_uuid': refresh_token.user_uuid,
+                    'tenant_uuid': refresh_token.tenant_uuid,
+                    'client_id': refresh_token.client_id,
+                    'mobile': refresh_token.mobile,
+                    'created_at': refresh_token.created_at,
+                    'user_agent': refresh_token.user_agent,
+                    'remote_addr': refresh_token.remote_addr,
+                }
+            )
+        return refresh_tokens
 
     def get_existing_refresh_token(self, client_id, user_uuid):
         filter_ = and_(
             RefreshToken.client_id == client_id, RefreshToken.user_uuid == user_uuid
         )
-        with self.new_session() as session:
-            query = session.query(RefreshToken).filter(filter_)
-            for refresh_token in query.all():
-                return refresh_token.uuid
+        query = self.session.query(RefreshToken).filter(filter_)
+        for refresh_token in query.all():
+            return refresh_token.uuid

--- a/wazo_auth/database/queries/refresh_token.py
+++ b/wazo_auth/database/queries/refresh_token.py
@@ -69,6 +69,7 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             .delete(synchronize_session=False)
         )
 
+        self.session.flush()
         if not nb_deleted:
             raise exceptions.UnknownRefreshToken(client_id)
 

--- a/wazo_auth/database/queries/refresh_token.py
+++ b/wazo_auth/database/queries/refresh_token.py
@@ -92,9 +92,9 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             RefreshToken.tenant_uuid.in_(tenant_uuids),
         )
 
-        query = self.session.query(RefreshToken.tenant_uuid, RefreshToken.mobile).filter(
-            filter_
-        )
+        query = self.session.query(
+            RefreshToken.tenant_uuid, RefreshToken.mobile
+        ).filter(filter_)
         for refresh_token in query.all():
             return {
                 'tenant_uuid': refresh_token.tenant_uuid,

--- a/wazo_auth/database/queries/session.py
+++ b/wazo_auth/database/queries/session.py
@@ -62,5 +62,6 @@ class SessionDAO(PaginatorMixin, BaseDAO):
 
         session_result = {'uuid': session.uuid, 'tenant_uuid': session.tenant_uuid}
         self.session.query(Session).filter(filter_).delete(synchronize_session=False)
+        self.session.flush()
 
         return session_result, token_result

--- a/wazo_auth/database/queries/session.py
+++ b/wazo_auth/database/queries/session.py
@@ -22,19 +22,19 @@ class SessionDAO(PaginatorMixin, BaseDAO):
         if user_uuid is not None:
             filter_ = and_(filter_, Token.auth_id == str(user_uuid))
 
-        with self.new_session() as s:
-            query = s.query(Session, Token).join(Token).filter(filter_)
-            query = self._paginator.update_query(query, **kwargs)
+        s = self.session
+        query = s.query(Session, Token).join(Token).filter(filter_)
+        query = self._paginator.update_query(query, **kwargs)
 
-            return [
-                {
-                    'uuid': result.Session.uuid,
-                    'mobile': result.Session.mobile,
-                    'tenant_uuid': result.Session.tenant_uuid,
-                    'user_uuid': result.Token.auth_id,
-                }
-                for result in query.all()
-            ]
+        return [
+            {
+                'uuid': result.Session.uuid,
+                'mobile': result.Session.mobile,
+                'tenant_uuid': result.Session.tenant_uuid,
+                'user_uuid': result.Token.auth_id,
+            }
+            for result in query.all()
+        ]
 
     def count(self, tenant_uuids=None, **kwargs):
         filter_ = text('true')
@@ -44,8 +44,8 @@ class SessionDAO(PaginatorMixin, BaseDAO):
                 return 0
             filter_ = and_(filter_, Session.tenant_uuid.in_(tenant_uuids))
 
-        with self.new_session() as s:
-            return s.query(Session).join(Token).filter(filter_).count()
+        s = self.session
+        return s.query(Session).join(Token).filter(filter_).count()
 
     def delete(self, session_uuid, tenant_uuids):
         filter_ = Session.uuid == str(session_uuid)
@@ -53,17 +53,17 @@ class SessionDAO(PaginatorMixin, BaseDAO):
             return {}, {}
         filter_ = and_(filter_, Session.tenant_uuid.in_(tenant_uuids))
 
-        with self.new_session() as s:
-            session = s.query(Session).filter(filter_).first()
-            if not session:
-                return {}, {}
+        s = self.session
+        session = s.query(Session).filter(filter_).first()
+        if not session:
+            return {}, {}
 
-            token_result = {}
-            for token in session.tokens:
-                token_result = {'uuid': token.uuid, 'auth_id': token.auth_id}
-                break
+        token_result = {}
+        for token in session.tokens:
+            token_result = {'uuid': token.uuid, 'auth_id': token.auth_id}
+            break
 
-            session_result = {'uuid': session.uuid, 'tenant_uuid': session.tenant_uuid}
-            s.query(Session).filter(filter_).delete(synchronize_session=False)
+        session_result = {'uuid': session.uuid, 'tenant_uuid': session.tenant_uuid}
+        s.query(Session).filter(filter_).delete(synchronize_session=False)
 
         return session_result, token_result

--- a/wazo_auth/database/queries/session.py
+++ b/wazo_auth/database/queries/session.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import text, and_
@@ -22,8 +22,7 @@ class SessionDAO(PaginatorMixin, BaseDAO):
         if user_uuid is not None:
             filter_ = and_(filter_, Token.auth_id == str(user_uuid))
 
-        s = self.session
-        query = s.query(Session, Token).join(Token).filter(filter_)
+        query = self.session.query(Session, Token).join(Token).filter(filter_)
         query = self._paginator.update_query(query, **kwargs)
 
         return [
@@ -44,8 +43,7 @@ class SessionDAO(PaginatorMixin, BaseDAO):
                 return 0
             filter_ = and_(filter_, Session.tenant_uuid.in_(tenant_uuids))
 
-        s = self.session
-        return s.query(Session).join(Token).filter(filter_).count()
+        return self.session.query(Session).join(Token).filter(filter_).count()
 
     def delete(self, session_uuid, tenant_uuids):
         filter_ = Session.uuid == str(session_uuid)
@@ -53,8 +51,7 @@ class SessionDAO(PaginatorMixin, BaseDAO):
             return {}, {}
         filter_ = and_(filter_, Session.tenant_uuid.in_(tenant_uuids))
 
-        s = self.session
-        session = s.query(Session).filter(filter_).first()
+        session = self.session.query(Session).filter(filter_).first()
         if not session:
             return {}, {}
 
@@ -64,6 +61,6 @@ class SessionDAO(PaginatorMixin, BaseDAO):
             break
 
         session_result = {'uuid': session.uuid, 'tenant_uuid': session.tenant_uuid}
-        s.query(Session).filter(filter_).delete(synchronize_session=False)
+        self.session.query(Session).filter(filter_).delete(synchronize_session=False)
 
         return session_result, token_result

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -150,6 +150,7 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
         try:
             self.session.query(Tenant).filter(filter_).update(values)
+            self.session.flush()
         except exc.IntegrityError as e:
             if e.orig.pgcode == self._FKEY_CONSTRAINT_CODE:
                 constraint = e.orig.diag.constraint_name

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -99,7 +99,7 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         nb_deleted = (
             self.session.query(Tenant).filter(Tenant.uuid == str(uuid)).delete()
         )
-
+        self.session.flush()
         if not nb_deleted:
             if not self.list_(uuid=uuid):
                 raise exceptions.UnknownTenantException(uuid)

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -80,9 +80,7 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             s.flush()
         except exc.IntegrityError as e:
             if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
-                column = self.constraint_to_column_map.get(
-                    e.orig.diag.constraint_name
-                )
+                column = self.constraint_to_column_map.get(e.orig.diag.constraint_name)
                 value = locals().get(column)
                 if column:
                     raise exceptions.ConflictException('tenants', column, value)
@@ -95,9 +93,7 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
     def find_top_tenant(self):
         s = self.session
-        return (
-            s.query(Tenant).filter(Tenant.uuid == Tenant.parent_uuid).first().uuid
-        )
+        return s.query(Tenant).filter(Tenant.uuid == Tenant.parent_uuid).first().uuid
 
     def delete(self, uuid):
         s = self.session
@@ -112,9 +108,7 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
     def get_address_id(self, tenant_uuid):
         s = self.session
         return (
-            s.query(Tenant.address_id)
-            .filter(Tenant.uuid == str(tenant_uuid))
-            .scalar()
+            s.query(Tenant.address_id).filter(Tenant.uuid == str(tenant_uuid)).scalar()
         )
 
     def list_(self, **kwargs):

--- a/wazo_auth/database/queries/token.py
+++ b/wazo_auth/database/queries/token.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -30,71 +30,71 @@ class TokenDAO(BaseDAO):
             session_body['tenant_uuid'] = self._get_default_tenant_uuid()
         token.session = Session(**session_body)
 
-        with self.new_session() as s:
-            s.add(token)
-            s.flush()
-            return token.uuid, token.session_uuid
+        s = self.session
+        s.add(token)
+        s.flush()
+        return token.uuid, token.session_uuid
 
     def _get_default_tenant_uuid(self):
-        with self.new_session() as s:
-            filter_ = Tenant.uuid == Tenant.parent_uuid
-            return s.query(Tenant).filter(filter_).first().uuid
+        s = self.session
+        filter_ = Tenant.uuid == Tenant.parent_uuid
+        return s.query(Tenant).filter(filter_).first().uuid
 
     def get(self, token_uuid):
-        with self.new_session() as s:
-            token = s.query(TokenModel).get(token_uuid)
-            if token:
-                return {
-                    'uuid': token.uuid,
-                    'auth_id': token.auth_id,
-                    'pbx_user_uuid': token.pbx_user_uuid,
-                    'xivo_uuid': token.xivo_uuid,
-                    'issued_t': token.issued_t,
-                    'expire_t': token.expire_t,
-                    'acls': [acl.value for acl in token.acls],
-                    'metadata': json.loads(token.metadata_) if token.metadata_ else {},
-                    'session_uuid': token.session_uuid,
-                    'remote_addr': token.remote_addr,
-                    'user_agent': token.user_agent,
-                }
+        s = self.session
+        token = s.query(TokenModel).get(token_uuid)
+        if token:
+            return {
+                'uuid': token.uuid,
+                'auth_id': token.auth_id,
+                'pbx_user_uuid': token.pbx_user_uuid,
+                'xivo_uuid': token.xivo_uuid,
+                'issued_t': token.issued_t,
+                'expire_t': token.expire_t,
+                'acls': [acl.value for acl in token.acls],
+                'metadata': json.loads(token.metadata_) if token.metadata_ else {},
+                'session_uuid': token.session_uuid,
+                'remote_addr': token.remote_addr,
+                'user_agent': token.user_agent,
+            }
 
-            raise exceptions.UnknownTokenException()
+        raise exceptions.UnknownTokenException()
 
     def delete(self, token_uuid):
         filter_ = TokenModel.uuid == token_uuid
 
-        with self.new_session() as s:
-            session_result = {}
-            token = s.query(TokenModel).filter(filter_).first()
-            if not token:
-                return {}, {}
+        s = self.session
+        session_result = {}
+        token = s.query(TokenModel).filter(filter_).first()
+        if not token:
+            return {}, {}
 
-            session = token.session
-            if len(session.tokens) == 1:
-                session_result = {
-                    'uuid': session.uuid,
-                    'tenant_uuid': session.tenant_uuid,
-                }
-                s.delete(session)
+        session = token.session
+        if len(session.tokens) == 1:
+            session_result = {
+                'uuid': session.uuid,
+                'tenant_uuid': session.tenant_uuid,
+            }
+            s.delete(session)
 
-            token_result = {'uuid': token.uuid, 'auth_id': token.auth_id}
-            s.query(TokenModel).filter(filter_).delete()
+        token_result = {'uuid': token.uuid, 'auth_id': token.auth_id}
+        s.query(TokenModel).filter(filter_).delete()
 
         return token_result, session_result
 
     def get_tokens_and_session_that_expire_soon(self, _time):
-        with self.new_session() as s:
-            tokens = self._get_tokens_with_expiration_less_than(s, time.time() + _time)
-            if not tokens:
-                return [], []
-            filter_ = TokenModel.uuid.in_([token['uuid'] for token in tokens])
-            sessions = self._get_sessions_from_token_filter(s, filter_)
+        s = self.session
+        tokens = self._get_tokens_with_expiration_less_than(s, time.time() + _time)
+        if not tokens:
+            return [], []
+        filter_ = TokenModel.uuid.in_([token['uuid'] for token in tokens])
+        sessions = self._get_sessions_from_token_filter(s, filter_)
         return tokens, sessions
 
     def delete_expired_tokens_and_sessions(self):
-        with self.new_session() as s:
-            tokens = self._delete_expired_tokens(s)
-            sessions = self._delete_expired_sessions(s)
+        s = self.session
+        tokens = self._delete_expired_tokens(s)
+        sessions = self._delete_expired_sessions(s)
         return tokens, sessions
 
     @staticmethod

--- a/wazo_auth/database/queries/token.py
+++ b/wazo_auth/database/queries/token.py
@@ -75,6 +75,7 @@ class TokenDAO(BaseDAO):
 
         token_result = {'uuid': token.uuid, 'auth_id': token.auth_id}
         self.session.query(TokenModel).filter(filter_).delete()
+        self.session.flush()
 
         return token_result, session_result
 
@@ -89,6 +90,7 @@ class TokenDAO(BaseDAO):
     def delete_expired_tokens_and_sessions(self):
         tokens = self._delete_expired_tokens()
         sessions = self._delete_expired_sessions()
+        self.session.flush()
         return tokens, sessions
 
     def _get_tokens_with_expiration_less_than(self, epoch):
@@ -122,6 +124,7 @@ class TokenDAO(BaseDAO):
         token_uuids = [token['uuid'] for token in results]
         filter_ = TokenModel.uuid.in_(token_uuids)
         self.session.query(TokenModel).filter(filter_).delete(synchronize_session=False)
+        self.session.flush()
         return results
 
     def _delete_expired_sessions(self):
@@ -132,4 +135,5 @@ class TokenDAO(BaseDAO):
         session_uuids = [session['uuid'] for session in results]
         filter_ = Session.uuid.in_(session_uuids)
         self.session.query(Session).filter(filter_).delete(synchronize_session=False)
+        self.session.flush()
         return results

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -31,29 +31,29 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
     def add_policy(self, user_uuid, policy_uuid):
         user_policy = UserPolicy(user_uuid=user_uuid, policy_uuid=policy_uuid)
-        with self.new_session() as s:
-            s.add(user_policy)
-            try:
-                s.flush()
-            except exc.IntegrityError as e:
-                if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
-                    # This association already exists.
-                    s.rollback()
-                    return
-                if e.orig.pgcode == self._FKEY_CONSTRAINT_CODE:
-                    constraint = e.orig.diag.constraint_name
-                    if constraint == 'auth_user_policy_user_uuid_fkey':
-                        raise exceptions.UnknownUserException(user_uuid)
-                    elif constraint == 'auth_user_policy_policy_uuid_fkey':
-                        raise exceptions.UnknownPolicyException(policy_uuid)
-                raise
+        s = self.session
+        s.add(user_policy)
+        try:
+            s.flush()
+        except exc.IntegrityError as e:
+            if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
+                # This association already exists.
+                s.rollback()
+                return
+            if e.orig.pgcode == self._FKEY_CONSTRAINT_CODE:
+                constraint = e.orig.diag.constraint_name
+                if constraint == 'auth_user_policy_user_uuid_fkey':
+                    raise exceptions.UnknownUserException(user_uuid)
+                elif constraint == 'auth_user_policy_policy_uuid_fkey':
+                    raise exceptions.UnknownPolicyException(policy_uuid)
+            raise
 
     def change_password(self, user_uuid, salt, hash_):
         filter_ = User.uuid == str(user_uuid)
         values = {'password_salt': salt, 'password_hash': hash_}
 
-        with self.new_session() as s:
-            s.query(User).filter(filter_).update(values)
+        s = self.session
+        s.query(User).filter(filter_).update(values)
 
     def exists(self, user_uuid, tenant_uuids=None):
         kwargs = {'uuid': user_uuid}
@@ -66,8 +66,8 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             UserPolicy.user_uuid == user_uuid, UserPolicy.policy_uuid == policy_uuid
         )
 
-        with self.new_session() as s:
-            return s.query(UserPolicy).filter(filter_).delete()
+        s = self.session
+        return s.query(UserPolicy).filter(filter_).delete()
 
     def count(self, **kwargs):
         filter_ = text('true')
@@ -86,14 +86,14 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             search_filter = self.new_search_filter(**kwargs)
             filter_ = and_(filter_, strict_filter, search_filter)
 
-        with self.new_session() as s:
-            return (
-                s.query(User.uuid)
-                .outerjoin(UserEmail, UserEmail.user_uuid == User.uuid)
-                .outerjoin(Email, Email.uuid == UserEmail.email_uuid)
-                .filter(filter_)
-                .count()
-            )
+        s = self.session
+        return (
+            s.query(User.uuid)
+            .outerjoin(UserEmail, UserEmail.user_uuid == User.uuid)
+            .outerjoin(Email, Email.uuid == UserEmail.email_uuid)
+            .filter(filter_)
+            .count()
+        )
 
     def count_groups(self, user_uuid, **kwargs):
         filtered = kwargs.get('filtered')
@@ -106,16 +106,16 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
         filter_ = and_(filter_, UserGroup.user_uuid == str(user_uuid))
 
-        with self.new_session() as s:
-            return s.query(Group).join(UserGroup).filter(filter_).count()
+        s = self.session
+        return s.query(Group).join(UserGroup).filter(filter_).count()
 
     def count_sessions(self, user_uuid, **kwargs):
         # filtered is not implemented
 
         filter_ = Token.auth_id == str(user_uuid)
 
-        with self.new_session() as s:
-            return s.query(Session).join(Token).filter(filter_).count()
+        s = self.session
+        return s.query(Session).join(Token).filter(filter_).count()
 
     def count_policies(self, user_uuid, **kwargs):
         filtered = kwargs.get('filtered')
@@ -128,13 +128,13 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
         filter_ = and_(filter_, UserPolicy.user_uuid == user_uuid)
 
-        with self.new_session() as s:
-            return (
-                s.query(Policy)
-                .join(UserPolicy, UserPolicy.policy_uuid == Policy.uuid)
-                .filter(filter_)
-                .count()
-            )
+        s = self.session
+        return (
+            s.query(Policy)
+            .join(UserPolicy, UserPolicy.policy_uuid == Policy.uuid)
+            .filter(filter_)
+            .count()
+        )
 
     def create(self, username, **kwargs):
         user_args = {
@@ -153,96 +153,96 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
         email_confirmed = kwargs.get('email_confirmed', False)
         email_address = kwargs.get('email_address', None)
-        with self.new_session() as s:
-            try:
-                if email_address:
-                    email_args = {
-                        'address': email_address,
-                        'confirmed': email_confirmed,
-                    }
-                    email = Email(**email_args)
-                    s.add(email)
-
-                user = User(**user_args)
-                s.add(user)
-                s.flush()
-                if email_address:
-                    user_email = UserEmail(
-                        user_uuid=user.uuid, email_uuid=email.uuid, main=True
-                    )
-                    s.add(user_email)
-                    s.flush()
-            except exc.IntegrityError as e:
-                if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
-                    column = self.constraint_to_column_map.get(
-                        e.orig.diag.constraint_name
-                    )
-                    value = locals().get(column)
-                    if column:
-                        raise exceptions.ConflictException('users', column, value)
-                raise
-
+        s = self.session
+        try:
             if email_address:
-                email = {
-                    'uuid': email.uuid,
+                email_args = {
                     'address': email_address,
                     'confirmed': email_confirmed,
-                    'main': True,
                 }
-                emails = [email]
-            else:
-                emails = []
+                email = Email(**email_args)
+                s.add(email)
 
-            return {
-                'uuid': user.uuid,
-                'username': username,
-                'firstname': user.firstname,
-                'lastname': user.lastname,
-                'purpose': user.purpose,
-                'emails': emails,
-                'enabled': user.enabled,
-                'tenant_uuid': user.tenant_uuid,
+            user = User(**user_args)
+            s.add(user)
+            s.flush()
+            if email_address:
+                user_email = UserEmail(
+                    user_uuid=user.uuid, email_uuid=email.uuid, main=True
+                )
+                s.add(user_email)
+                s.flush()
+        except exc.IntegrityError as e:
+            if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
+                column = self.constraint_to_column_map.get(
+                    e.orig.diag.constraint_name
+                )
+                value = locals().get(column)
+                if column:
+                    raise exceptions.ConflictException('users', column, value)
+            raise
+
+        if email_address:
+            email = {
+                'uuid': email.uuid,
+                'address': email_address,
+                'confirmed': email_confirmed,
+                'main': True,
             }
+            emails = [email]
+        else:
+            emails = []
+
+        return {
+            'uuid': user.uuid,
+            'username': username,
+            'firstname': user.firstname,
+            'lastname': user.lastname,
+            'purpose': user.purpose,
+            'emails': emails,
+            'enabled': user.enabled,
+            'tenant_uuid': user.tenant_uuid,
+        }
 
     def delete(self, user_uuid):
-        with self.new_session() as s:
-            user = s.query(User).filter(User.uuid == str(user_uuid)).first()
+        s = self.session
+        user = s.query(User).filter(User.uuid == str(user_uuid)).first()
 
-            if not user:
-                raise exceptions.UnknownUserException(user_uuid)
+        if not user:
+            raise exceptions.UnknownUserException(user_uuid)
 
-            s.delete(user)
+        s.delete(user)
 
     def get_credentials(self, username):
         filter_ = and_(
             self.new_strict_filter(username=username), User.enabled.is_(True)
         )
 
-        with self.new_session() as s:
-            query = s.query(User.password_salt, User.password_hash).filter(filter_)
+        s = self.session
+        query = s.query(User.password_salt, User.password_hash).filter(filter_)
 
-            for row in query.all():
-                return row.password_hash, row.password_salt
+        for row in query.all():
+            return row.password_hash, row.password_salt
 
-            raise exceptions.UnknownUsernameException(username)
+        raise exceptions.UnknownUsernameException(username)
 
     def get_emails(self, user_uuid):
         result = []
 
-        with self.new_session() as s:
-            user = s.query(User).filter(User.uuid == str(user_uuid)).first()
-            if not user:
-                raise exceptions.UnknownUserException(user_uuid)
+        s = self.session
+        user = s.query(User).filter(User.uuid == str(user_uuid)).first()
+        if not user:
+            raise exceptions.UnknownUserException(user_uuid)
 
-            for item in user.emails:
-                result.append(
-                    {
-                        'uuid': item.email.uuid,
-                        'address': item.email.address,
-                        'main': item.main,
-                        'confirmed': item.email.confirmed,
-                    }
-                )
+        for item in user.emails:
+            result.append(
+                {
+                    'uuid': item.email.uuid,
+                    'address': item.email.address,
+                    'main': item.main,
+                    'confirmed': item.email.confirmed,
+                }
+            )
 
         return result
 
@@ -260,59 +260,59 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             filter_ = and_(filter_, User.tenant_uuid == str(tenant_uuid))
 
         users = []
-        with self.new_session() as s:
-            query = (
-                s.query(User)
-                .outerjoin(UserEmail)
-                .outerjoin(Email)
-                .outerjoin(UserGroup)
-                .filter(filter_)
-            )
-            query = self._paginator.update_query(query, **kwargs)
+        s = self.session
+        query = (
+            s.query(User)
+            .outerjoin(UserEmail)
+            .outerjoin(Email)
+            .outerjoin(UserGroup)
+            .filter(filter_)
+        )
+        query = self._paginator.update_query(query, **kwargs)
 
-            for user in query.all():
-                emails = []
-                for item in user.emails:
-                    emails.append(
-                        {
-                            'uuid': item.email.uuid,
-                            'address': item.email.address,
-                            'main': item.main,
-                            'confirmed': item.email.confirmed,
-                        }
-                    )
-
-                users.append(
+        for user in query.all():
+            emails = []
+            for item in user.emails:
+                emails.append(
                     {
-                        'username': user.username,
-                        'uuid': user.uuid,
-                        'enabled': user.enabled,
-                        'emails': emails,
-                        'firstname': user.firstname,
-                        'lastname': user.lastname,
-                        'purpose': user.purpose,
-                        'tenant_uuid': user.tenant_uuid,
+                        'uuid': item.email.uuid,
+                        'address': item.email.address,
+                        'main': item.main,
+                        'confirmed': item.email.confirmed,
                     }
                 )
+
+            users.append(
+                {
+                    'username': user.username,
+                    'uuid': user.uuid,
+                    'enabled': user.enabled,
+                    'emails': emails,
+                    'firstname': user.firstname,
+                    'lastname': user.lastname,
+                    'purpose': user.purpose,
+                    'tenant_uuid': user.tenant_uuid,
+                }
+            )
 
         return users
 
     def update(self, user_uuid, **kwargs):
         filter_ = User.uuid == str(user_uuid)
 
-        with self.new_session() as s:
-            s.query(User).filter(filter_).update(kwargs)
+        s = self.session
+        s.query(User).filter(filter_).update(kwargs)
 
     def update_emails(self, user_uuid, emails):
         existing_addresses = self._emails_to_dict(self.get_emails(user_uuid))
         emails_as_dict = self._emails_to_dict(emails)
         updated_emails = self._merge_existing_emails(emails_as_dict, existing_addresses)
 
-        with self.new_session() as s:
-            self._delete_all_emails(s, user_uuid)
+        s = self.session
+        self._delete_all_emails(s, user_uuid)
 
-            for email in updated_emails.values():
-                self._add_user_email(s, user_uuid, email)
+        for email in updated_emails.values():
+            self._add_user_email(s, user_uuid, email)
 
         return emails
 

--- a/wazo_auth/plugins/external_auth/google/websocket_oauth2.py
+++ b/wazo_auth/plugins/external_auth/google/websocket_oauth2.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -8,6 +8,7 @@ from threading import Thread
 import websocket
 
 from wazo_auth.exceptions import ExternalAuthAlreadyExists
+from wazo_auth.database.helpers import Session
 from .helpers import get_timestamp_expiration
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,10 @@ class WebSocketOAuth2(Thread):
             msg = json.loads(message)
             self.ws.close()
             self.create_first_token(self.user_uuid, msg.get('code'))
+            try:
+                Session.commit()
+            finally:
+                Session.close()
         except Exception as e:
             logger.error('error when receiving websocket event %s', e)
 

--- a/wazo_auth/plugins/external_auth/google/websocket_oauth2.py
+++ b/wazo_auth/plugins/external_auth/google/websocket_oauth2.py
@@ -8,7 +8,7 @@ from threading import Thread
 import websocket
 
 from wazo_auth.exceptions import ExternalAuthAlreadyExists
-from wazo_auth.database.helpers import Session
+from wazo_auth.database.helpers import commit_or_rollback
 from .helpers import get_timestamp_expiration
 
 logger = logging.getLogger(__name__)
@@ -51,10 +51,7 @@ class WebSocketOAuth2(Thread):
             msg = json.loads(message)
             self.ws.close()
             self.create_first_token(self.user_uuid, msg.get('code'))
-            try:
-                Session.commit()
-            finally:
-                Session.close()
+            commit_or_rollback()
         except Exception as e:
             logger.error('error when receiving websocket event %s', e)
 

--- a/wazo_auth/plugins/external_auth/microsoft/websocket_oauth2.py
+++ b/wazo_auth/plugins/external_auth/microsoft/websocket_oauth2.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -8,6 +8,7 @@ from threading import Thread
 import websocket
 
 from wazo_auth.exceptions import ExternalAuthAlreadyExists
+from wazo_auth.database.helpers import Session
 from .helpers import get_timestamp_expiration
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,10 @@ class WebSocketOAuth2(Thread):
             self.ws.close()
             self.ws = None
         self.create_first_token(self.user_uuid, msg.get('code'))
+        try:
+            Session.commit()
+        finally:
+            Session.close()
 
     def _on_error(self, error):
         logger.error(error)

--- a/wazo_auth/plugins/external_auth/microsoft/websocket_oauth2.py
+++ b/wazo_auth/plugins/external_auth/microsoft/websocket_oauth2.py
@@ -8,7 +8,7 @@ from threading import Thread
 import websocket
 
 from wazo_auth.exceptions import ExternalAuthAlreadyExists
-from wazo_auth.database.helpers import Session
+from wazo_auth.database.helpers import commit_or_rollback
 from .helpers import get_timestamp_expiration
 
 logger = logging.getLogger(__name__)
@@ -55,10 +55,7 @@ class WebSocketOAuth2(Thread):
             self.ws.close()
             self.ws = None
         self.create_first_token(self.user_uuid, msg.get('code'))
-        try:
-            Session.commit()
-        finally:
-            Session.close()
+        commit_or_rollback()
 
     def _on_error(self, error):
         logger.error(error)

--- a/wazo_auth/services/external_auth.py
+++ b/wazo_auth/services/external_auth.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -11,6 +11,7 @@ import marshmallow
 from xivo_bus.resources.auth import events
 
 from wazo_auth.services.helpers import BaseService
+from wazo_auth.database.helpers import Session
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,10 @@ class _OAuth2Synchronizer:
         try:
             msg = json.loads(msg)
             success_cb(msg)
+            try:
+                Session.commit()
+            finally:
+                Session.close()
             self._bus_publisher.publish(event)
         finally:
             ws.close()

--- a/wazo_auth/services/external_auth.py
+++ b/wazo_auth/services/external_auth.py
@@ -11,7 +11,7 @@ import marshmallow
 from xivo_bus.resources.auth import events
 
 from wazo_auth.services.helpers import BaseService
-from wazo_auth.database.helpers import Session
+from wazo_auth.database.helpers import commit_or_rollback
 
 logger = logging.getLogger(__name__)
 
@@ -46,10 +46,7 @@ class _OAuth2Synchronizer:
         try:
             msg = json.loads(msg)
             success_cb(msg)
-            try:
-                Session.commit()
-            finally:
-                Session.close()
+            commit_or_rollback()
             self._bus_publisher.publish(event)
         finally:
             ws.close()

--- a/wazo_auth/token.py
+++ b/wazo_auth/token.py
@@ -168,6 +168,7 @@ class ExpiredTokenRemover:
             tokens, sessions = self._dao.token.delete_expired_tokens_and_sessions()
             Session.commit()
         except Exception:
+            Session.rollback()
             logger.warning(
                 'failed to remove expired tokens and sessions', exc_info=self._debug
             )


### PR DESCRIPTION
This PR changes the management of database sessions. Sessions are committed at the end of each HTTP session. If an error occurs during the handling of the HTTP request the session will be rolledback.

There are some areas of wazo-auth where requests happen outside the scope of an HTTP request. In those areas I committed and closed the session manually.

* Expired token/session thread
* Bootstrap script
* OAuth2 ws callbacks