### PR TITLE
set the db max connections to max_threads

### DIFF
--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -37,7 +37,7 @@ def _check_required_config_for_other_threads(config):
 
 class Controller:
     def __init__(self, config):
-        init_db(config['db_uri'])
+        init_db(config['db_uri'], max_connections=config['rest_api']['max_threads'])
         self._config = config
         _check_required_config_for_other_threads(config)
         self._service_discovery_args = [

--- a/wazo_auth/database/helpers.py
+++ b/wazo_auth/database/helpers.py
@@ -6,9 +6,13 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 
 Session = scoped_session(sessionmaker())
 
+DEFAULT_POOL_SIZE = 5
 
-def init_db(db_uri):
-    engine = create_engine(db_uri, pool_pre_ping=True)
+
+def init_db(db_uri, max_connections=15):
+    max_overflow = max_connections - DEFAULT_POOL_SIZE
+    max_overflow = 10 if max_overflow < 10 else max_overflow
+    engine = create_engine(db_uri, max_overflow=max_overflow, pool_pre_ping=True)
     Session.configure(bind=engine)
 
 


### PR DESCRIPTION
reason: db connection is scoped to the HTTP request and to avoid some
deadlock or slowdown, we should set the max connections equal to the
max_threads

According the max_threads, you may need to increase the maximum database
connection in the postgresql configuration file

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1712