### PR TITLE
add ACL for dird graphql schema to users

### DIFF
--- a/alembic/versions/03f4ae2b1853_add_graphql_schema_acl_to_users.py
+++ b/alembic/versions/03f4ae2b1853_add_graphql_schema_acl_to_users.py
@@ -1,0 +1,112 @@
+"""add graphql schema acl to users
+
+Revision ID: 03f4ae2b1853
+Revises: 2d4882d39dbb
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '03f4ae2b1853'
+down_revision = '2d4882d39dbb'
+
+POLICY_NAME = 'wazo_default_user_policy'
+ACL_TEMPLATES = ['dird.graphql.__schema']
+
+policy_table = sa.sql.table(
+    'auth_policy', sa.Column('uuid', sa.String(38)), sa.Column('name', sa.String(80))
+)
+acl_template_table = sa.sql.table(
+    'auth_acl_template', sa.Column('id', sa.Integer), sa.Column('template', sa.Text)
+)
+policy_template = sa.sql.table(
+    'auth_policy_template',
+    sa.Column('policy_uuid', sa.String(38)),
+    sa.Column('template_id', sa.Integer),
+)
+
+
+def _find_acl_template(conn, acl_template):
+    query = (
+        sa.sql.select([acl_template_table.c.id])
+        .where(acl_template_table.c.template == acl_template)
+        .limit(1)
+    )
+    return conn.execute(query).scalar()
+
+
+def _find_acl_templates(conn, acl_templates):
+    acl_template_ids = []
+    for acl_template in acl_templates:
+        acl_template_id = _find_acl_template(conn, acl_template)
+        if acl_template_id:
+            acl_template_ids.append(acl_template_id)
+    return acl_template_ids
+
+
+def _get_policy_uuid(conn, policy_name):
+    policy_query = sa.sql.select([policy_table.c.uuid]).where(
+        policy_table.c.name == policy_name
+    )
+
+    for policy in conn.execute(policy_query).fetchall():
+        return policy[0]
+
+
+def _insert_acl_template(conn, acl_templates):
+    acl_template_ids = []
+    for acl_template in acl_templates:
+        acl_template_id = _find_acl_template(conn, acl_template)
+        if not acl_template_id:
+            query = (
+                acl_template_table.insert()
+                .returning(acl_template_table.c.id)
+                .values(template=acl_template)
+            )
+            acl_template_id = conn.execute(query).scalar()
+        acl_template_ids.append(acl_template_id)
+    return acl_template_ids
+
+
+def _get_acl_template_ids(conn, policy_uuid):
+    query = sa.sql.select([policy_template.c.template_id]).where(
+        policy_template.c.policy_uuid == policy_uuid
+    )
+    return [acl_template_id for (acl_template_id,) in conn.execute(query).fetchall()]
+
+
+def upgrade():
+    conn = op.get_bind()
+    policy_uuid = _get_policy_uuid(conn, POLICY_NAME)
+    if not policy_uuid:
+        return
+
+    acl_template_ids = _insert_acl_template(conn, ACL_TEMPLATES)
+    acl_template_ids_already_associated = _get_acl_template_ids(conn, policy_uuid)
+    for template_id in set(acl_template_ids) - set(acl_template_ids_already_associated):
+        query = policy_template.insert().values(
+            policy_uuid=policy_uuid, template_id=template_id
+        )
+        conn.execute(query)
+
+
+def downgrade():
+    conn = op.get_bind()
+    acl_template_ids = _find_acl_templates(conn, ACL_TEMPLATES)
+    if not acl_template_ids:
+        return
+
+    policy_uuid = _get_policy_uuid(conn, POLICY_NAME)
+    if not policy_uuid:
+        return
+
+    delete_query = policy_template.delete().where(
+        sa.sql.and_(
+            policy_template.c.policy_uuid == policy_uuid,
+            policy_template.c.template_id.in_(acl_template_ids),
+        )
+    )
+    op.execute(delete_query)

--- a/integration_tests/suite/test_email_confirmation.py
+++ b/integration_tests/suite/test_email_confirmation.py
@@ -61,8 +61,8 @@ class TestEmailConfirmation(WazoAuthTestCase):
         self.client.users.request_confirmation_email(user['uuid'], email_uuid)
 
         last_email = self.get_emails()[-1]
-        url = [l for l in last_email.split('\n') if l.startswith('https://')][0]
-        url = url.replace('https', 'http')
+        urls = [line for line in last_email.split('\n') if line.startswith('https://')]
+        url = urls[0].replace('https://', 'http://')
         result = requests.get(url)
         assert_that(
             result,


### PR DESCRIPTION
Why:

* Users should be able to get the introspection data from GraphQL, e.g.
to have autocompletion in GraphQL UI.

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1778