### PR TITLE
test_tokens: avoid autogenerating attributes when searching

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -150,6 +150,13 @@ class BaseTestCase(AuthLaunchingTestCase):
         bus_client = BusClient.from_connection_fields(port=port, **self.bus_config)
         return bus_client.accumulator(routing_key)
 
+    def get_last_email_url(self):
+        last_email = self.get_emails()[-1]
+        email_urls = [
+            line for line in last_email.split('\n') if line.startswith('https://')
+        ]
+        return email_urls[-1]
+
     def get_emails(self):
         return [self._email_body(f) for f in self._get_email_filenames()]
 

--- a/integration_tests/suite/test_email_confirmation.py
+++ b/integration_tests/suite/test_email_confirmation.py
@@ -60,9 +60,8 @@ class TestEmailConfirmation(WazoAuthTestCase):
 
         self.client.users.request_confirmation_email(user['uuid'], email_uuid)
 
-        last_email = self.get_emails()[-1]
-        url = [l for l in last_email.split('\n') if l.startswith('https://')][0]
-        url = url.replace('https', 'http')
+        url = self.get_last_email_url()
+        url = url.replace('https://', 'http://')
         result = requests.get(url)
         assert_that(
             result,

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
@@ -257,8 +257,12 @@ class TestTokens(WazoAuthTestCase):
         until.assert_(bus_received_msg, tries=10, interval=0.25)
 
     @fixtures.http.user(username='foo', password='bar')
-    @fixtures.http.token(username='foo', password='bar', access_type='offline')
-    @fixtures.http.token(username='foo', password='bar', access_type='offline')
+    @fixtures.http.token(
+        username='foo', password='bar', access_type='offline', client_id='client1'
+    )
+    @fixtures.http.token(
+        username='foo', password='bar', access_type='offline', client_id='client2'
+    )
     @fixtures.http.token(
         username='foo',
         password='bar',
@@ -399,8 +403,12 @@ class TestTokens(WazoAuthTestCase):
 
     @fixtures.http.tenant()
     @fixtures.http.user(username='foo', password='bar')
-    @fixtures.http.token(username='foo', password='bar', access_type='offline')
-    @fixtures.http.token(username='foo', password='bar', access_type='offline')
+    @fixtures.http.token(
+        username='foo', password='bar', access_type='offline', client_id='client1'
+    )
+    @fixtures.http.token(
+        username='foo', password='bar', access_type='offline', client_id='client2'
+    )
     @fixtures.http.token(
         username='foo',
         password='bar',

--- a/integration_tests/suite/test_users.py
+++ b/integration_tests/suite/test_users.py
@@ -316,8 +316,7 @@ class TestUsers(WazoAuthTestCase):
                 ),
             )
 
-            last_email = self.get_emails()[-1]
-            url = [l for l in last_email.split('\n') if l.startswith('https://')][0]
+            url = self.get_last_email_url()
             url = url.replace('https', 'http')
             requests.get(url)
 


### PR DESCRIPTION
Why:

* Tests sometimes fail because the autogenerated client_id matches "baz"