### PR TITLE
Pull request for WAZO-1840-remove-auth-pid

### DIFF
--- a/debian/wazo-auth.service
+++ b/debian/wazo-auth.service
@@ -1,13 +1,14 @@
 [Unit]
 Description=wazo-auth server
 After=network.target postgresql.service
-Before=monit.service
+StartLimitBurst=15
+StartLimitIntervalSec=150
 
 [Service]
-ExecStartPre=/usr/bin/install -d -o wazo-auth -g wazo-auth /run/wazo-auth
 ExecStart=/usr/bin/wazo-auth
 ExecStartPost=/usr/bin/wazo-auth-wait
-PIDFile=/run/wazo-auth/wazo-auth.pid
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/wazo-auth/config.yml
+++ b/etc/wazo-auth/config.yml
@@ -7,7 +7,6 @@
 extra_config_files: /etc/wazo-auth/conf.d/
 
 log_filename: /var/log/wazo-auth.log
-pid_filename: /run/wazo-auth/wazo-auth.pid
 debug: False
 
 # The lifetime of tokens in seconds

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -16,7 +16,6 @@ _DEFAULT_CONFIG = {
     'extra_config_files': '/etc/wazo-auth/conf.d',
     'log_level': 'info',
     'log_filename': '/var/log/wazo-auth.log',
-    'pid_filename': '/run/wazo-auth/wazo-auth.pid',
     'default_token_lifetime': TWO_HOURS,
     'token_cleanup_interval': 60.0,
     'password_reset_expiration': 172800,

--- a/wazo_auth/main.py
+++ b/wazo_auth/main.py
@@ -6,7 +6,6 @@ import logging
 
 from xivo import xivo_logging
 from xivo.config_helper import set_xivo_uuid, UUIDNotFound
-from xivo.daemonize import pidfile_context
 from xivo.user_rights import change_user
 
 from wazo_auth.config import get_config
@@ -16,8 +15,6 @@ SPAMMY_LOGGERS = ['urllib3', 'Flask-Cors', 'amqp', 'kombu']
 
 logger = logging.getLogger(__name__)
 
-FOREGROUND = True  # Always in foreground systemd takes care of daemonizing
-
 
 def main():
     xivo_logging.silence_loggers(SPAMMY_LOGGERS, logging.WARNING)
@@ -25,7 +22,7 @@ def main():
     config = get_config(sys.argv[1:])
 
     xivo_logging.setup_logging(
-        config['log_filename'], FOREGROUND, config['debug'], config['log_level'],
+        config['log_filename'], debug=config['debug'], log_level=config['log_level'],
     )
 
     user = config.get('user')
@@ -39,8 +36,7 @@ def main():
             raise
 
     controller = Controller(config)
-    with pidfile_context(config['pid_filename'], FOREGROUND):
-        try:
-            controller.run()
-        except KeyboardInterrupt:
-            pass
+    try:
+        controller.run()
+    except KeyboardInterrupt:
+        pass

--- a/wazo_auth/main.py
+++ b/wazo_auth/main.py
@@ -36,7 +36,4 @@ def main():
             raise
 
     controller = Controller(config)
-    try:
-        controller.run()
-    except KeyboardInterrupt:
-        pass
+    controller.run()


### PR DESCRIPTION
reason: systemd restart is to remove monit usage based on pid file