### PR TITLE
blackify

### DIFF
--- a/alembic/versions/1ad2bb5e31e6_update_tables_to_cascade_delete.py
+++ b/alembic/versions/1ad2bb5e31e6_update_tables_to_cascade_delete.py
@@ -21,7 +21,10 @@ user_email_tbl = sa.sql.table(
     sa.Column('main'),
 )
 email_tbl = sa.sql.table(
-    'auth_email', sa.Column('uuid'), sa.Column('user_uuid'), sa.Column('main'),
+    'auth_email',
+    sa.Column('uuid'),
+    sa.Column('user_uuid'),
+    sa.Column('main'),
 )
 external_auth_config_tbl = sa.sql.table(
     'auth_external_auth_config',
@@ -38,7 +41,9 @@ user_external_auth_tbl = sa.sql.table(
     sa.Column('data'),
 )
 external_auth_data_tbl = sa.sql.table(
-    'auth_external_auth_data', sa.Column('uuid'), sa.Column('data'),
+    'auth_external_auth_data',
+    sa.Column('uuid'),
+    sa.Column('data'),
 )
 
 
@@ -88,7 +93,8 @@ def remove_middle_table_between_user_email():
 
 def merge_external_auth_data_with_external_auth_config():
     op.add_column(
-        'auth_external_auth_config', sa.Column('data', sa.Text, nullable=True),
+        'auth_external_auth_config',
+        sa.Column('data', sa.Text, nullable=True),
     )
     sub_query = sa.sql.select([external_auth_data_tbl.c.data]).where(
         external_auth_config_tbl.c.data_uuid == external_auth_data_tbl.c.uuid
@@ -105,7 +111,8 @@ def merge_external_auth_data_with_external_auth_config():
 
 def merge_external_auth_data_with_user_external_auth():
     op.add_column(
-        'auth_user_external_auth', sa.Column('data', sa.Text, nullable=True),
+        'auth_user_external_auth',
+        sa.Column('data', sa.Text, nullable=True),
     )
     sub_query = sa.sql.select([external_auth_data_tbl.c.data]).where(
         user_external_auth_tbl.c.external_auth_data_uuid
@@ -168,7 +175,9 @@ def add_middle_table_between_user_email():
     for email in emails:
         op.execute(
             user_email_tbl.insert().values(
-                user_uuid=email.user_uuid, email_uuid=email.uuid, main=email.main,
+                user_uuid=email.user_uuid,
+                email_uuid=email.uuid,
+                main=email.main,
             )
         )
 

--- a/integration_tests/suite/database/test_db_refresh_token.py
+++ b/integration_tests/suite/database/test_db_refresh_token.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
@@ -120,7 +120,10 @@ class TestRefreshTokenDAO(base.DAOTestCase):
         )
         assert_that(result, contains_inanyorder(has_entries(uuid=token_2)))
 
-        result = self._refresh_token_dao.list_(user_uuid=ALICE_UUID, mobile=True,)
+        result = self._refresh_token_dao.list_(
+            user_uuid=ALICE_UUID,
+            mobile=True,
+        )
         assert_that(result, contains_inanyorder(has_entries(uuid=token_1)))
 
         result = self._refresh_token_dao.list_(user_uuid=ALICE_UUID, search='foo')

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -233,7 +233,8 @@ class TestTokens(WazoAuthTestCase):
     def test_refresh_token_deleted_event(self, token, user):
         client_id = 'foobar'
         routing_key = 'auth.users.{user_uuid}.tokens.{client_id}.deleted'.format(
-            user_uuid=user['uuid'], client_id=client_id,
+            user_uuid=user['uuid'],
+            client_id=client_id,
         )
         msg_accumulator = self.new_message_accumulator(routing_key)
 

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -40,7 +40,9 @@ class Address(Base):
 
     id_ = Column(Integer, name='id', primary_key=True)
     tenant_uuid = Column(
-        String(38), ForeignKey('auth_tenant.uuid', ondelete='CASCADE'), nullable=False,
+        String(38),
+        ForeignKey('auth_tenant.uuid', ondelete='CASCADE'),
+        nullable=False,
     )
     line_1 = Column(Text)
     line_2 = Column(Text)
@@ -61,7 +63,9 @@ class Email(Base):
     confirmed = Column(Boolean, nullable=False, default=False)
     main = Column(Boolean, nullable=False, default=False)
     user_uuid = Column(
-        String(38), ForeignKey('auth_user.uuid', ondelete='CASCADE'), nullable=False,
+        String(38),
+        ForeignKey('auth_user.uuid', ondelete='CASCADE'),
+        nullable=False,
     )
 
 

--- a/wazo_auth/database/queries/external_auth.py
+++ b/wazo_auth/database/queries/external_auth.py
@@ -63,7 +63,9 @@ class ExternalAuthDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         data = json.dumps(data)
         external_type = self._find_or_create_type(auth_type)
         external_auth_config = ExternalAuthConfig(
-            tenant_uuid=tenant_uuid, type_uuid=external_type.uuid, data=data,
+            tenant_uuid=tenant_uuid,
+            type_uuid=external_type.uuid,
+            data=data,
         )
         self.session.add(external_auth_config)
         try:

--- a/wazo_auth/database/queries/refresh_token.py
+++ b/wazo_auth/database/queries/refresh_token.py
@@ -50,7 +50,8 @@ class RefreshTokenDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                 if constraint == 'auth_refresh_token_client_id_user_uuid':
                     self.session.rollback()
                     raise exceptions.DuplicatedRefreshTokenException(
-                        body['user_uuid'], body['client_id'],
+                        body['user_uuid'],
+                        body['client_id'],
                     )
             raise
 

--- a/wazo_auth/main.py
+++ b/wazo_auth/main.py
@@ -22,7 +22,9 @@ def main():
     config = get_config(sys.argv[1:])
 
     xivo_logging.setup_logging(
-        config['log_filename'], debug=config['debug'], log_level=config['log_level'],
+        config['log_filename'],
+        debug=config['debug'],
+        log_level=config['log_level'],
     )
 
     user = config.get('user')

--- a/wazo_auth/plugins/http/password_reset/http.py
+++ b/wazo_auth/plugins/http/password_reset/http.py
@@ -43,7 +43,10 @@ class PasswordReset(http.ErrorCatchingResource):
             if email_address:
                 connection_params = extract_connection_params(request.headers)
                 self.email_service.send_reset_email(
-                    user['uuid'], user['username'], email_address, connection_params,
+                    user['uuid'],
+                    user['username'],
+                    email_address,
+                    connection_params,
                 )
             else:
                 logger.debug('No confirmed email %s', args)

--- a/wazo_auth/plugins/http/tokens/http.py
+++ b/wazo_auth/plugins/http/tokens/http.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -116,7 +116,8 @@ class RefreshTokens(_BaseRefreshTokens):
         scoping_tenant = Tenant.autodetect()
 
         search_params = self._build_search_params(
-            user_uuid=None, scoping_tenant_uuid=scoping_tenant.uuid,
+            user_uuid=None,
+            scoping_tenant_uuid=scoping_tenant.uuid,
         )
 
         refresh_tokens = self._token_service.list_refresh_tokens(**search_params)

--- a/wazo_auth/plugins/http/user_registration/http.py
+++ b/wazo_auth/plugins/http/user_registration/http.py
@@ -35,7 +35,10 @@ class Register(http.ErrorCatchingResource):
                     continue
                 connection_params = extract_connection_params(request.headers)
                 self.email_service.send_confirmation_email(
-                    result['username'], e['uuid'], address, connection_params,
+                    result['username'],
+                    e['uuid'],
+                    address,
+                    connection_params,
                 )
         except Exception:
             self.user_service.delete_user(tenant['uuid'], result['uuid'])

--- a/wazo_auth/services/token.py
+++ b/wazo_auth/services/token.py
@@ -41,7 +41,9 @@ class TokenService(BaseService):
     def delete_refresh_token(self, scoping_tenant_uuid, user_uuid, client_id):
         tenant_uuids = self._get_scoped_tenant_uuids(scoping_tenant_uuid, True)
         refresh_token = self._dao.refresh_token.get_by_user(
-            tenant_uuids=tenant_uuids, user_uuid=user_uuid, client_id=client_id,
+            tenant_uuids=tenant_uuids,
+            user_uuid=user_uuid,
+            client_id=client_id,
         )
 
         event = RefreshTokenDeletedEvent(
@@ -109,7 +111,8 @@ class TokenService(BaseService):
                 refresh_token = self._dao.refresh_token.create(body)
             except DuplicatedRefreshTokenException:
                 refresh_token = self._dao.refresh_token.get_existing_refresh_token(
-                    args['client_id'], metadata['uuid'],
+                    args['client_id'],
+                    metadata['uuid'],
                 )
             else:
                 event = RefreshTokenCreatedEvent(


### PR DESCRIPTION
Why:
Some rules seem to have changed with black. This brings wazo-auth up to
date without introducing formatting noise in other branches.