### PR TITLE
Pull request for WAZO-1958-group-for-all-users

### DIFF
--- a/alembic/alembic_acl_template.py.mako
+++ b/alembic/alembic_acl_template.py.mako
@@ -7,7 +7,6 @@ Revises: ${down_revision}
 
 from alembic import op
 import sqlalchemy as sa
-${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}

--- a/alembic/alembic_template.py.mako
+++ b/alembic/alembic_template.py.mako
@@ -5,13 +5,12 @@ Revises: ${down_revision}
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
-
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 
 def upgrade():

--- a/alembic/versions/16f98957ec7e_add_wazo_all_users_group.py
+++ b/alembic/versions/16f98957ec7e_add_wazo_all_users_group.py
@@ -1,0 +1,52 @@
+"""add wazo-all-users group
+
+Revision ID: 16f98957ec7e
+Revises: 91e8de642bee
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '16f98957ec7e'
+down_revision = '91e8de642bee'
+
+from alembic import op
+import sqlalchemy as sa
+
+group_table = sa.sql.table(
+    'auth_group', sa.Column('uuid'), sa.Column('tenant_uuid'), sa.Column('name')
+)
+tenant_table = sa.sql.table('auth_tenant', sa.Column('uuid'), sa.Column('parent_uuid'))
+
+
+def all_tenant_uuids():
+    query = sa.sql.select([tenant_table.c.uuid])
+    for row in op.get_bind().execute(query):
+        yield row.uuid
+
+
+def create_wazo_all_users_group(tenant_uuid):
+    query = (
+        group_table.insert()
+        .returning(group_table.c.uuid)
+        .values(name=f'wazo-all-users-tenant-{tenant_uuid}', tenant_uuid=tenant_uuid)
+    )
+    group_uuid = op.get_bind().execute(query).scalar()
+
+    return group_uuid
+
+
+def delete_wazo_all_users_group(tenant_uuid):
+    query = group_table.delete().where(
+        group_table.c.name == f'wazo-all-users-tenant-{tenant_uuid}'
+    )
+    op.execute(query)
+
+
+def upgrade():
+    for tenant_uuid in all_tenant_uuids():
+        group_uuid = create_wazo_all_users_group(tenant_uuid)
+
+
+def downgrade():
+    for tenant_uuid in all_tenant_uuids():
+        delete_wazo_all_users_group(tenant_uuid)

--- a/alembic/versions/16f98957ec7e_add_wazo_all_users_group.py
+++ b/alembic/versions/16f98957ec7e_add_wazo_all_users_group.py
@@ -5,12 +5,12 @@ Revises: 91e8de642bee
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '16f98957ec7e'
 down_revision = '91e8de642bee'
-
-from alembic import op
-import sqlalchemy as sa
 
 group_table = sa.sql.table(
     'auth_group', sa.Column('uuid'), sa.Column('tenant_uuid'), sa.Column('name')

--- a/alembic/versions/16f98957ec7e_add_wazo_all_users_group.py
+++ b/alembic/versions/16f98957ec7e_add_wazo_all_users_group.py
@@ -16,6 +16,17 @@ group_table = sa.sql.table(
     'auth_group', sa.Column('uuid'), sa.Column('tenant_uuid'), sa.Column('name')
 )
 tenant_table = sa.sql.table('auth_tenant', sa.Column('uuid'), sa.Column('parent_uuid'))
+user_group_table = sa.sql.table(
+    'auth_user_group',
+    sa.Column('user_uuid'),
+    sa.Column('group_uuid'),
+    sa.Column('tenant_uuid'),
+)
+user_table = sa.sql.table(
+    'auth_user',
+    sa.Column('uuid'),
+    sa.Column('tenant_uuid', None, sa.ForeignKey('auth_tenant.uuid')),
+)
 
 
 def all_tenant_uuids():
@@ -42,9 +53,28 @@ def delete_wazo_all_users_group(tenant_uuid):
     op.execute(query)
 
 
+def add_all_users_in_group(group_uuids):
+    group_members_query = (
+        sa.sql.select([user_table.c.uuid, group_table.c.uuid])
+        .select_from(
+            user_table.join(
+                tenant_table, user_table.c.tenant_uuid == tenant_table.c.uuid
+            ).join(group_table, tenant_table.c.uuid == group_table.c.tenant_uuid)
+        )
+        .where(group_table.c.uuid.in_(group_uuids))
+    )
+    query = user_group_table.insert().from_select(
+        [user_group_table.c.user_uuid, user_group_table.c.group_uuid],
+        group_members_query,
+    )
+    op.get_bind().execute(query)
+
+
 def upgrade():
+    group_uuids = set()
     for tenant_uuid in all_tenant_uuids():
-        group_uuid = create_wazo_all_users_group(tenant_uuid)
+        group_uuids.add(create_wazo_all_users_group(tenant_uuid))
+    add_all_users_in_group(group_uuids)
 
 
 def downgrade():

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -100,12 +100,17 @@ class DAOTestCase(unittest.TestCase):
         self._session_dao = session.SessionDAO()
 
         self.top_tenant_uuid = self._tenant_dao.find_top_tenant()
+        self._remove_unrelated_default_autocreate_objects()
 
         self.session.begin_nested()
 
     def tearDown(self):
         self.session.rollback()
         helpers.Session.remove()
+
+    def _remove_unrelated_default_autocreate_objects(self):
+        for item in self._group_dao.list_():
+            self._group_dao.delete(item['uuid'])
 
     @contextmanager
     def auto_rollback(self):

--- a/integration_tests/suite/helpers/constants.py
+++ b/integration_tests/suite/helpers/constants.py
@@ -1,7 +1,8 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 
 UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000'
 DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@localhost:{port}')
+NB_DEFAULT_GROUPS = 1

--- a/integration_tests/suite/test_default_token_metadata.py
+++ b/integration_tests/suite/test_default_token_metadata.py
@@ -1,7 +1,7 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, has_entries
+from hamcrest import assert_that, has_entries, has_items
 from .helpers import fixtures
 from .helpers.base import WazoAuthTestCase
 
@@ -23,7 +23,7 @@ class TestDefaultTokenMetadata(WazoAuthTestCase):
             has_entries(
                 uuid=user['uuid'],
                 tenant_uuid=self.tenant_uuid,
-                groups=contains(has_entries(uuid=group['uuid'])),
+                groups=has_items(has_entries(uuid=group['uuid'])),
                 auth_id=user['uuid'],
                 username=user['username'],
                 xivo_uuid='the-predefined-xivo-uuid',

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from functools import partial
@@ -58,6 +58,27 @@ class TestTenants(WazoAuthTestCase):
                 phone=PHONE_1,
                 parent_uuid=self.top_tenant_uuid,
                 address=has_entries(**ADDRESS_1),
+            ),
+        )
+
+        wazo_all_users_groups = self.client.groups.list(
+            search='wazo-all-users', recurse=True
+        )
+        assert_that(
+            wazo_all_users_groups['items'],
+            contains_inanyorder(
+                has_entries(
+                    name=f'wazo-all-users-tenant-{foobar["uuid"]}',
+                    tenant_uuid=foobar['uuid'],
+                ),
+                has_entries(
+                    name=f'wazo-all-users-tenant-{foobaz["uuid"]}',
+                    tenant_uuid=foobaz['uuid'],
+                ),
+                has_entries(
+                    name=f'wazo-all-users-tenant-{other["uuid"]}',
+                    tenant_uuid=other['uuid'],
+                ),
             ),
         )
 

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -68,6 +68,10 @@ class TestTenants(WazoAuthTestCase):
             wazo_all_users_groups['items'],
             contains_inanyorder(
                 has_entries(
+                    name=f'wazo-all-users-tenant-{self.top_tenant_uuid}',
+                    tenant_uuid=self.top_tenant_uuid,
+                ),
+                has_entries(
                     name=f'wazo-all-users-tenant-{foobar["uuid"]}',
                     tenant_uuid=foobar['uuid'],
                 ),

--- a/integration_tests/suite/test_users.py
+++ b/integration_tests/suite/test_users.py
@@ -12,6 +12,7 @@ from hamcrest import (
     equal_to,
     is_not,
     has_entries,
+    has_item,
     has_items,
     has_key,
     has_properties,
@@ -134,6 +135,18 @@ class TestUsers(WazoAuthTestCase):
                 tenants['items'], has_items(has_entries(uuid=self.top_tenant_uuid))
             )
 
+            wazo_all_users_group = self.client.groups.list(
+                name=f'wazo-all-users-tenant-{self.top_tenant_uuid}',
+                tenant_uuid=self.top_tenant_uuid,
+            )['items'][0]
+            wazo_all_users_group_members = self.client.groups.get_users(
+                wazo_all_users_group['uuid']
+            )['items']
+            assert_that(
+                wazo_all_users_group_members,
+                has_item(has_entries({'uuid': user['uuid']})),
+            )
+
         # User created in subtenant
         with self.user(self.client, tenant_uuid=isolated['uuid'], **args) as user:
             assert_that(
@@ -247,7 +260,7 @@ class TestUsers(WazoAuthTestCase):
                 client.users.edit,
                 user['uuid'],
                 tenant_uuid=self.top_tenant_uuid,
-                **body
+                **body,
             )
             assert_no_error(self.client.users.edit, bob['uuid'], **body)
 

--- a/integration_tests/suite/test_wazo_user_backend.py
+++ b/integration_tests/suite/test_wazo_user_backend.py
@@ -1,7 +1,7 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, has_entries, has_items
+from hamcrest import assert_that, has_entries, has_items
 from .helpers import fixtures
 from .helpers.base import assert_http_error, WazoAuthTestCase
 from xivo_test_helpers.hamcrest.uuid_ import uuid_
@@ -54,7 +54,7 @@ class TestWazoUserBackend(WazoAuthTestCase):
                 xivo_uuid='the-predefined-xivo-uuid',
                 uuid=user['uuid'],
                 tenant_uuid=top_tenant['uuid'],
-                groups=contains(has_entries(uuid=group['uuid'])),
+                groups=has_items(has_entries(uuid=group['uuid'])),
             ),
         )
 

--- a/wazo_auth/bootstrap.py
+++ b/wazo_auth/bootstrap.py
@@ -104,7 +104,8 @@ def create_initial_user(db_uri, username, password, purpose, policy_name):
     dao = queries.DAO.from_defaults()
     tenant_tree = services.helpers.TenantTree(dao.tenant)
     policy_service = services.PolicyService(dao, tenant_tree)
-    user_service = services.UserService(dao, tenant_tree)
+    group_service = services.GroupService(dao, tenant_tree)
+    user_service = services.UserService(dao, tenant_tree, group_service)
     if user_service.verify_password(username, password):
         # Already bootstrapped, just skip
         return

--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -81,7 +81,7 @@ class Controller:
         )
         self._user_service = services.UserService(dao, self._tenant_tree)
         self._tenant_service = services.TenantService(
-            dao, self._tenant_tree, self._bus_publisher
+            dao, self._tenant_tree, group_service, self._bus_publisher
         )
 
         self._metadata_plugins = plugin_helpers.load(

--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -79,7 +79,7 @@ class Controller:
         session_service = services.SessionService(
             dao, self._tenant_tree, self._bus_publisher
         )
-        self._user_service = services.UserService(dao, self._tenant_tree)
+        self._user_service = services.UserService(dao, self._tenant_tree, group_service)
         self._tenant_service = services.TenantService(
             dao, self._tenant_tree, group_service, self._bus_publisher
         )

--- a/wazo_auth/services/group.py
+++ b/wazo_auth/services/group.py
@@ -46,6 +46,17 @@ class GroupService(BaseService):
 
         raise exceptions.UnknownGroupException(group_uuid)
 
+    def get_all_users_group(self, tenant_uuid):
+        args = {
+            'name': f'wazo-all-users-tenant-{tenant_uuid}',
+            'limit': 1,
+            'tenant_uuids': [tenant_uuid],
+        }
+
+        matching_groups = self._dao.group.list_(**args)
+        for group in matching_groups:
+            return group
+
     def get_acl_templates(self, username):
         users = self._dao.user.list_(username=username, limit=1)
         acl_templates = []

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -7,9 +7,10 @@ from wazo_auth.services.helpers import BaseService
 
 
 class TenantService(BaseService):
-    def __init__(self, dao, tenant_tree, bus_publisher=None):
+    def __init__(self, dao, tenant_tree, group_service, bus_publisher=None):
         super().__init__(dao, tenant_tree)
         self._bus_publisher = bus_publisher
+        self._group_service = group_service
 
     def assert_tenant_under(self, scoping_tenant_uuid, tenant_uuid):
         visible_tenants = self.list_sub_tenants(scoping_tenant_uuid)
@@ -79,6 +80,10 @@ class TenantService(BaseService):
 
         event = events.TenantCreatedEvent(uuid, kwargs.get('name'))
         self._bus_publisher.publish(event)
+
+        self._group_service.create(
+            name=f'wazo-all-users-tenant-{uuid}', tenant_uuid=uuid
+        )
 
         return result
 

--- a/wazo_auth/services/user.py
+++ b/wazo_auth/services/user.py
@@ -13,9 +13,10 @@ logger = logging.getLogger(__name__)
 
 
 class UserService(BaseService):
-    def __init__(self, dao, tenant_tree, encrypter=None):
+    def __init__(self, dao, tenant_tree, group_service, encrypter=None):
         super().__init__(dao, tenant_tree)
         self._encrypter = encrypter or PasswordEncrypter()
+        self._group_service = group_service
 
     def add_policy(self, user_uuid, policy_uuid):
         self._dao.user.add_policy(user_uuid, policy_uuid)
@@ -115,6 +116,11 @@ class UserService(BaseService):
 
         kwargs.setdefault('tenant_uuid', self._dao.tenant.find_top_tenant())
         user = self._dao.user.create(**kwargs)
+
+        wazo_all_users_group = self._group_service.get_all_users_group(
+            kwargs['tenant_uuid']
+        )
+        self._group_service.add_user(wazo_all_users_group['uuid'], user['uuid'])
 
         return user
 

--- a/wazo_auth/tests/test_services.py
+++ b/wazo_auth/tests/test_services.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, calling, equal_to, has_entries, not_, raises
@@ -235,8 +235,12 @@ class TestUserService(BaseServiceTestCase):
     def setUp(self):
         super().setUp()
         self.tenant_tree = Mock()
+        self.group_service = Mock()
         self.service = services.UserService(
-            self.dao, self.tenant_tree, encrypter=self.encrypter
+            self.dao,
+            self.tenant_tree,
+            self.group_service,
+            encrypter=self.encrypter,
         )
 
     def test_change_password(self):
@@ -335,6 +339,7 @@ class TestUserService(BaseServiceTestCase):
             'tenant_uuid': s.tenant_uuid,
         }
         self.user_dao.create.return_value = {'uuid': s.user_uuid}
+        self.group_service.get_all_users_group.return_value = {'uuid': ''}
 
         result = self.service.new_user(**params)
 


### PR DESCRIPTION
tenants: create wazo-all-users group with new tenants
tenants: add wazo-all-users groups to existing tenants
users: add new users into wazo-all-users group
users: add existing users to wazo-all-users group
wazo-all-users migration: optimize queries
wazo-all-users: rename already existing groups