### PR TITLE
test: avoid search with two char

### DIFF
--- a/integration_tests/suite/test_groups.py
+++ b/integration_tests/suite/test_groups.py
@@ -160,13 +160,13 @@ class TestGroups(base.WazoAuthTestCase):
         assert_that(response, has_entries(items=not_(has_items(one))))
 
     @fixtures.http.tenant(uuid=base.SUB_TENANT_UUID)
-    @fixtures.http.group(name='one-12', tenant_uuid=base.SUB_TENANT_UUID)
-    @fixtures.http.group(name='two-12', tenant_uuid=base.SUB_TENANT_UUID)
+    @fixtures.http.group(name='group-12-one', tenant_uuid=base.SUB_TENANT_UUID)
+    @fixtures.http.group(name='group-12-two', tenant_uuid=base.SUB_TENANT_UUID)
     @fixtures.http.group(name='three', tenant_uuid=base.SUB_TENANT_UUID)
     def test_list_searching(self, three, two, one, _):
         action = partial(self.client.groups.list, tenant_uuid=base.SUB_TENANT_UUID)
 
-        response = action(search='one-12')
+        response = action(search='group-12-one')
         assert_that(
             response,
             has_entries(
@@ -176,7 +176,7 @@ class TestGroups(base.WazoAuthTestCase):
             ),
         )
 
-        response = action(search='12')
+        response = action(search='group-12')
         assert_that(
             response,
             has_entries(

--- a/integration_tests/suite/test_user_group.py
+++ b/integration_tests/suite/test_user_group.py
@@ -63,9 +63,9 @@ class TestGroupUserList(base.WazoAuthTestCase):
 class TestUserGroupList(base.WazoAuthTestCase):
     def setUp(self):
         super().setUp()
-        self.foo = self.client.groups.new(name='foo')
-        self.bar = self.client.groups.new(name='bar')
-        self.baz = self.client.groups.new(name='baz')
+        self.foo = self.client.groups.new(name='group-foo')
+        self.bar = self.client.groups.new(name='group-bar')
+        self.baz = self.client.groups.new(name='group-baz')
         self.total = 3 + NB_DEFAULT_GROUPS
         self.ignored = self.client.groups.new(name='ignored')
         self.user = self.client.users.new(username='alice')
@@ -87,11 +87,11 @@ class TestUserGroupList(base.WazoAuthTestCase):
             has_entries(total=self.total, filtered=self.total, items=expected),
         )
 
-        result = self.action(search='ba')
+        result = self.action(search='group-ba')
         expected = contains_inanyorder(self.bar, self.baz)
         assert_that(result, has_entries(total=self.total, filtered=2, items=expected))
 
-        result = self.action(name='foo')
+        result = self.action(name='group-foo')
         expected = contains_inanyorder(self.foo)
         assert_that(result, has_entries(total=self.total, filtered=1, items=expected))
 


### PR DESCRIPTION
reason: we create a default group with a uuid inside the name, so
searching with only two char can found this group