### PR TITLE
Pull request for WAZO-1959-policy-for-all-users

### DIFF
--- a/alembic/versions/21a6a7b5c9b0_add_config_managed_column_to_policies.py
+++ b/alembic/versions/21a6a7b5c9b0_add_config_managed_column_to_policies.py
@@ -1,0 +1,30 @@
+"""add config_managed column to policies
+
+Revision ID: 21a6a7b5c9b0
+Revises: 16f98957ec7e
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '21a6a7b5c9b0'
+down_revision = '16f98957ec7e'
+
+
+def upgrade():
+    op.add_column(
+        'auth_policy',
+        sa.Column(
+            'config_managed',
+            sa.Boolean,
+            default=False,
+            server_default='false',
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column('auth_policy', 'config_managed')

--- a/integration_tests/assets/etc/wazo-auth/conf.d/asset.base.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/asset.base.yml
@@ -13,3 +13,8 @@ backend_policies:
 password_reset_email_template: '/var/lib/wazo-auth/templates/raw_password_reset_email.jinja'
 email_confirmation_get_response_body_template: '/var/lib/wazo-auth/templates/email_confirmation_get_body.jinja'
 email_confirmation_get_mimetype: 'text/x-test'
+all_users_policies:
+  wazo-all-users-policy:
+    acl_templates:
+      - integration_tests.acl
+      - integration_tests.another_acl

--- a/integration_tests/suite/database/test_db_policy.py
+++ b/integration_tests/suite/database/test_db_policy.py
@@ -256,7 +256,7 @@ class TestPolicyDAO(base.DAOTestCase):
 
     def test_update(self):
         assert_that(
-            calling(self._policy_dao.update).with_args(UNKNOWN_UUID, 'foo', '', []),
+            calling(self._policy_dao.update).with_args(UNKNOWN_UUID, 'foo', '', [], False),
             raises(exceptions.UnknownPolicyException),
         )
 
@@ -268,6 +268,7 @@ class TestPolicyDAO(base.DAOTestCase):
                 'foobaz',
                 'A new description',
                 ['confd.line.{{ line_id }}', 'dird.#', 'ctid-ng.#'],
+                False,
             )
             policy = self.get_policy(uuid_)
 
@@ -299,7 +300,7 @@ class TestPolicyDAO(base.DAOTestCase):
     def _new_policy(self, name, description, acl_templates=None, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self.top_tenant_uuid
         acl_templates = acl_templates or []
-        uuid_ = self._policy_dao.create(name, description, acl_templates, tenant_uuid)
+        uuid_ = self._policy_dao.create(name, description, acl_templates, False, tenant_uuid)
         try:
             yield uuid_
         finally:

--- a/integration_tests/suite/database/test_db_policy.py
+++ b/integration_tests/suite/database/test_db_policy.py
@@ -256,7 +256,9 @@ class TestPolicyDAO(base.DAOTestCase):
 
     def test_update(self):
         assert_that(
-            calling(self._policy_dao.update).with_args(UNKNOWN_UUID, 'foo', '', [], False),
+            calling(self._policy_dao.update).with_args(
+                UNKNOWN_UUID, 'foo', '', [], False
+            ),
             raises(exceptions.UnknownPolicyException),
         )
 
@@ -300,7 +302,9 @@ class TestPolicyDAO(base.DAOTestCase):
     def _new_policy(self, name, description, acl_templates=None, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self.top_tenant_uuid
         acl_templates = acl_templates or []
-        uuid_ = self._policy_dao.create(name, description, acl_templates, False, tenant_uuid)
+        uuid_ = self._policy_dao.create(
+            name, description, acl_templates, False, tenant_uuid
+        )
         try:
             yield uuid_
         finally:

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -237,8 +237,9 @@ class BaseTestCase(AuthLaunchingTestCase):
         return client.token.check_scopes(token, scopes, tenant)['scopes']
 
     @classmethod
-    def new_auth_client(cls, username=None, password=None):
-        kwargs = {'port': cls.auth_port, 'prefix': '', 'https': False}
+    def new_auth_client(cls, username=None, password=None, port=None):
+        port = port or cls.auth_port
+        kwargs = {'port': port, 'prefix': '', 'https': False}
 
         if username and password:
             kwargs['username'] = username

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -259,6 +259,16 @@ class BaseTestCase(AuthLaunchingTestCase):
         helpers.deinit_db()
         helpers.init_db(database.uri)
 
+    @classmethod
+    def restart_auth(cls):
+        cls.restart_service('auth')
+
+        cls.auth_port = cls.service_port(9497, service_name='auth')
+        cls.client = cls.new_auth_client(cls.username, cls.password)
+        until.return_(cls.client.status.check, timeout=30)
+        token_data = cls.client.token.new(backend='wazo_user', expiration=7200)
+        cls.client.set_token(token_data['token'])
+
 
 class WazoAuthTestCase(BaseTestCase):
 

--- a/integration_tests/suite/helpers/constants.py
+++ b/integration_tests/suite/helpers/constants.py
@@ -6,5 +6,7 @@ import os
 UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000'
 UNKNOWN_TENANT = '55ee61f3-c4a5-427c-9f40-9d5c33466240'
 DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@localhost:{port}')
-NB_DEFAULT_GROUPS = 1
 ISO_DATETIME = '%Y-%m-%dT%H:%M:%S.%f'
+NB_DEFAULT_GROUPS = 1
+NB_DEFAULT_POLICIES = 1
+DEFAULT_POLICY_NAME = 'wazo-all-users-policy'

--- a/integration_tests/suite/helpers/fixtures/db.py
+++ b/integration_tests/suite/helpers/fixtures/db.py
@@ -175,6 +175,7 @@ def group(**group_args):
 
 def policy(**policy_args):
     policy_args.setdefault('name', _random_string(20))
+    policy_args.setdefault('config_managed', False)
     policy_args['acl_templates'] = policy_args.get('acl_templates') or []
     policy_args['description'] = policy_args.get('description', '')
 

--- a/integration_tests/suite/helpers/fixtures/http.py
+++ b/integration_tests/suite/helpers/fixtures/http.py
@@ -164,7 +164,7 @@ def policy(**policy_args):
         @wraps(decorated)
         def wrapper(self, *args, **kwargs):
             policy = self.client.policies.new(**policy_args)
-            if policy_args['config_managed']:
+            if policy_args.get('config_managed'):
                 db_client = self.new_db_client()
                 set_policy_config_managed(db_client, policy['uuid'])
             try:

--- a/integration_tests/suite/helpers/fixtures/http.py
+++ b/integration_tests/suite/helpers/fixtures/http.py
@@ -157,9 +157,7 @@ def policy(**policy_args):
     def set_policy_config_managed(db_client, policy_uuid):
         with db_client.connect() as connection:
             connection.execute(
-                (
-                    f"UPDATE auth_policy set config_managed=true WHERE uuid = '{policy_uuid}'"
-                )
+                f"UPDATE auth_policy set config_managed=true WHERE uuid = '{policy_uuid}'"
             )
 
     def decorator(decorated):

--- a/integration_tests/suite/test_group_policy.py
+++ b/integration_tests/suite/test_group_policy.py
@@ -234,7 +234,14 @@ class TestGroupPolicyAssociation(base.WazoAuthTestCase):
 
         group_policies = self.client.groups.get_policies(group['uuid'])['items']
         assert_that(
-            group_policies, not_(has_item(has_entries(uuid=policy['uuid'],))),
+            group_policies,
+            not_(
+                has_item(
+                    has_entries(
+                        uuid=policy['uuid'],
+                    )
+                )
+            ),
         )
 
         base.assert_http_error(404, self.client.policies.get, policy['uuid'])

--- a/integration_tests/suite/test_group_policy.py
+++ b/integration_tests/suite/test_group_policy.py
@@ -12,7 +12,7 @@ from hamcrest import (
 )
 from xivo_test_helpers import until
 from .helpers import base, fixtures
-from .helpers.constants import UNKNOWN_UUID
+from .helpers.constants import UNKNOWN_UUID, DEFAULT_POLICY_NAME
 
 
 class TestGroupPolicyAssociation(base.WazoAuthTestCase):
@@ -184,7 +184,7 @@ class TestGroupPolicyAssociation(base.WazoAuthTestCase):
         assert_that(token_data, has_entries('acls', has_items(*expected_acls)))
 
     def test_all_users_policies_are_updated_at_startup(self):
-        policy = self.client.policies.list(name='wazo-all-users-policy')['items'][0]
+        policy = self.client.policies.list(name=DEFAULT_POLICY_NAME)['items'][0]
         policy_without_acl = dict(policy)
         policy_without_acl['acl_templates'] = []
         self.client.policies.edit(policy['uuid'], **policy_without_acl)
@@ -200,7 +200,7 @@ class TestGroupPolicyAssociation(base.WazoAuthTestCase):
         group = self.client.groups.list(
             name=f'wazo-all-users-tenant-{self.top_tenant_uuid}'
         )['items'][0]
-        policy = self.client.policies.list(name='wazo-all-users-policy')['items'][0]
+        policy = self.client.policies.list(name=DEFAULT_POLICY_NAME)['items'][0]
         policy_without_acl = dict(policy)
         policy_without_acl['acl_templates'] = []
         self.client.policies.edit(policy['uuid'], **policy_without_acl)

--- a/integration_tests/suite/test_group_policy.py
+++ b/integration_tests/suite/test_group_policy.py
@@ -10,7 +10,6 @@ from hamcrest import (
     has_items,
     has_item,
 )
-from xivo_test_helpers import until
 from .helpers import base, fixtures
 from .helpers.constants import UNKNOWN_UUID, DEFAULT_POLICY_NAME
 

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -12,6 +12,7 @@ from hamcrest import (
     empty,
     equal_to,
     has_entries,
+    has_key,
     has_item,
     has_items,
     none,

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -139,7 +139,8 @@ class TestPolicies(WazoAuthTestCase):
     def test_list_sorting(self, three, two, one, _):
         action = partial(self.client.policies.list, tenant_uuid=SUB_TENANT_UUID)
         autocreated_policy = self.client.policies.list(
-            name=DEFAULT_POLICY_NAME, tenant_uuid=SUB_TENANT_UUID,
+            name=DEFAULT_POLICY_NAME,
+            tenant_uuid=SUB_TENANT_UUID,
         )['items'][0]
         expected = [one, three, two, autocreated_policy]
         assert_sorted(action, order='name', expected=expected)
@@ -164,7 +165,8 @@ class TestPolicies(WazoAuthTestCase):
         assert_that(
             response,
             has_entries(
-                total=3 + NB_DEFAULT_POLICIES, items=has_items(one, two, three),
+                total=3 + NB_DEFAULT_POLICIES,
+                items=has_items(one, two, three),
             ),
         )
 

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -5,12 +5,14 @@ import json
 import requests
 from functools import partial
 from hamcrest import (
+    all_of,
     assert_that,
     contains,
     contains_inanyorder,
     empty,
     equal_to,
     has_entries,
+    has_item,
     has_items,
     none,
     not_,
@@ -25,7 +27,7 @@ from .helpers.base import (
     WazoAuthTestCase,
 )
 from .helpers import fixtures
-from .helpers.constants import UNKNOWN_UUID
+from .helpers.constants import UNKNOWN_UUID, NB_DEFAULT_POLICIES, DEFAULT_POLICY_NAME
 
 
 class TestPolicies(WazoAuthTestCase):
@@ -136,7 +138,10 @@ class TestPolicies(WazoAuthTestCase):
     @fixtures.http.policy(name='three', tenant_uuid=SUB_TENANT_UUID)
     def test_list_sorting(self, three, two, one, _):
         action = partial(self.client.policies.list, tenant_uuid=SUB_TENANT_UUID)
-        expected = [one, three, two]
+        autocreated_policy = self.client.policies.list(
+            name=DEFAULT_POLICY_NAME, tenant_uuid=SUB_TENANT_UUID,
+        )['items'][0]
+        expected = [one, three, two, autocreated_policy]
         assert_sorted(action, order='name', expected=expected)
 
     @fixtures.http.tenant(uuid=SUB_TENANT_UUID)
@@ -157,7 +162,10 @@ class TestPolicies(WazoAuthTestCase):
         # Same tenant
         response = self.client.policies.list(tenant_uuid=SUB_TENANT_UUID)
         assert_that(
-            response, has_entries(total=3, items=contains_inanyorder(one, two, three))
+            response,
+            has_entries(
+                total=3 + NB_DEFAULT_POLICIES, items=has_items(one, two, three),
+            ),
         )
 
     @fixtures.http.tenant(uuid=SUB_TENANT_UUID)
@@ -176,13 +184,19 @@ class TestPolicies(WazoAuthTestCase):
         response = self.client.policies.list(
             tenant_uuid=SUB_TENANT_UUID, order='name', limit=1
         )
-        assert_that(response, has_entries(total=3, items=contains(one)))
+        assert_that(
+            response, has_entries(total=3 + NB_DEFAULT_POLICIES, items=contains(one))
+        )
 
         response = self.client.policies.list(
             tenant_uuid=SUB_TENANT_UUID, order='name', offset=1
         )
         assert_that(
-            response, has_entries(total=3, items=contains_inanyorder(two, three))
+            response,
+            has_entries(
+                total=3 + NB_DEFAULT_POLICIES,
+                items=all_of(has_items(two, three), not_(has_item(one))),
+            ),
         )
 
     @fixtures.http.policy(

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -12,7 +12,6 @@ from hamcrest import (
     empty,
     equal_to,
     has_entries,
-    has_key,
     has_item,
     has_items,
     none,

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -280,7 +280,8 @@ class TestTenantPolicyAssociation(WazoAuthTestCase):
 
         result = action(search='ba')
         expected = contains_inanyorder(
-            has_entries(name='bar'), has_entries(name='baz'),
+            has_entries(name='bar'),
+            has_entries(name='baz'),
         )
         assert_that(
             result,
@@ -330,7 +331,10 @@ class TestTenantPolicyAssociation(WazoAuthTestCase):
         )
 
         result = action(limit=2)
-        expected = contains(has_entries(name='bar'), has_entries(name='baz'),)
+        expected = contains(
+            has_entries(name='bar'),
+            has_entries(name='baz'),
+        )
         assert_that(
             result,
             has_entries(

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -8,7 +8,6 @@ from hamcrest import (
     contains_inanyorder,
     equal_to,
     has_entries,
-    has_items,
     has_item,
 )
 from xivo_test_helpers.hamcrest.uuid_ import uuid_
@@ -105,7 +104,17 @@ class TestTenants(WazoAuthTestCase):
         ]
         assert_that(
             wazo_all_users_policies,
-            has_items(
+            contains_inanyorder(
+                has_entries(
+                    group=has_entries(tenant_uuid=self.top_tenant_uuid),
+                    policies=contains(
+                        has_entries(
+                            name=f'wazo-all-users-policy',
+                            tenant_uuid=self.top_tenant_uuid,
+                            acl_templates=has_item('integration_tests.acl'),
+                        )
+                    ),
+                ),
                 has_entries(
                     group=has_entries(tenant_uuid=foobar['uuid']),
                     policies=contains(

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -105,6 +105,7 @@ _DEFAULT_CONFIG = {
         'exchange_type': 'topic',
     },
     'smtp': {'hostname': 'localhost', 'port': 25},
+    'db_connect_retry_timeout_seconds': 300,
     'db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk',
     'confd_db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk',
     'all_users_policies': {},

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -107,6 +107,7 @@ _DEFAULT_CONFIG = {
     'smtp': {'hostname': 'localhost', 'port': 25},
     'db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk',
     'confd_db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk',
+    'all_users_policies': {},
 }
 
 

--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -88,6 +88,12 @@ class Controller:
             config['all_users_policies'],
             self._bus_publisher,
         )
+        self._all_users_service = services.AllUsersService(
+            group_service,
+            policy_service,
+            self._tenant_service,
+            config['all_users_policies'],
+        )
 
         self._metadata_plugins = plugin_helpers.load(
             namespace='wazo_auth.metadata',
@@ -166,6 +172,7 @@ class Controller:
 
         with bus.publisher_thread(self._bus_publisher):
             with ServiceCatalogRegistration(*self._service_discovery_args):
+                self._all_users_service.update_policies()
                 self._expired_token_remover.start()
                 local_token_renewer = self._get_local_token_renewer()
                 self._config['local_token_renewer'] = local_token_renewer

--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -81,7 +81,12 @@ class Controller:
             config, dao, self._tenant_tree, self._bus_publisher, self._user_service
         )
         self._tenant_service = services.TenantService(
-            dao, self._tenant_tree, group_service, self._bus_publisher
+            dao,
+            self._tenant_tree,
+            group_service,
+            policy_service,
+            config['all_users_policies'],
+            self._bus_publisher,
         )
 
         self._metadata_plugins = plugin_helpers.load(

--- a/wazo_auth/database/helpers.py
+++ b/wazo_auth/database/helpers.py
@@ -1,8 +1,16 @@
 # Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
+import time
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
+
+logger = logging.getLogger(__name__)
+
 
 Session = scoped_session(sessionmaker())
 
@@ -34,3 +42,25 @@ def commit_or_rollback():
         raise
     finally:
         Session.close()
+
+
+@contextmanager
+def db_ready(timeout):
+    start_time = datetime.now()
+    end_time = start_time + timedelta(seconds=timeout)
+    while datetime.now() < end_time:
+        try:
+            ping_db()
+        except Exception as e:
+            logger.warning('fail to connect to the database: %s', e)
+            time.sleep(0.5)
+        else:
+            yield
+            return
+
+    # Timeout expired, let it raise this time
+    ping_db()
+
+
+def ping_db():
+    get_db_session().get_bind().execute('SELECT 1')

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -215,6 +215,9 @@ class Policy(Base):
     tenant_uuid = Column(
         String(38), ForeignKey('auth_tenant.uuid', ondelete='CASCADE'), nullable=False
     )
+    config_managed = Column(
+        Boolean, default=False, server_default='false', nullable=True,
+    )
     tenant = relationship('Tenant', cascade='all, delete-orphan', single_parent=True)
 
 

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -216,7 +216,10 @@ class Policy(Base):
         String(38), ForeignKey('auth_tenant.uuid', ondelete='CASCADE'), nullable=False
     )
     config_managed = Column(
-        Boolean, default=False, server_default='false', nullable=True,
+        Boolean,
+        default=False,
+        server_default='false',
+        nullable=True,
     )
     tenant = relationship('Tenant', cascade='all, delete-orphan', single_parent=True)
 

--- a/wazo_auth/plugins/http/group_policy/http.py
+++ b/wazo_auth/plugins/http/group_policy/http.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -8,6 +8,7 @@ import marshmallow
 
 from wazo_auth import exceptions, http, schemas
 from wazo_auth.flask_helpers import Tenant
+from wazo_auth.plugins.http.policies.schemas import policy_schema
 
 logger = logging.getLogger(__name__)
 
@@ -53,9 +54,10 @@ class GroupPolicies(_BaseResource):
         except marshmallow.ValidationError as e:
             raise exceptions.InvalidListParamException(e.messages)
 
+        policies = self.group_service.list_policies(group_uuid, **list_params)
         return (
             {
-                'items': self.group_service.list_policies(group_uuid, **list_params),
+                'items': policy_schema.dump(policies, many=True),
                 'total': self.group_service.count_policies(
                     group_uuid, filtered=False, **list_params
                 ),

--- a/wazo_auth/plugins/http/policies/http.py
+++ b/wazo_auth/plugins/http/policies/http.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request
@@ -6,7 +6,7 @@ import marshmallow
 
 from wazo_auth import exceptions, http, schemas
 from wazo_auth.flask_helpers import Tenant
-from .schemas import PolicySchema
+from .schemas import policy_schema
 
 
 class _BasePolicyRessource(http.AuthResource):
@@ -17,9 +17,8 @@ class _BasePolicyRessource(http.AuthResource):
 class Policies(_BasePolicyRessource):
     @http.required_acl('auth.policies.create')
     def post(self):
-        schema = PolicySchema()
         try:
-            body = schema.load(request.get_json(force=True))
+            body = policy_schema.load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             for field in e.messages:
                 raise exceptions.InvalidInputException(field)
@@ -27,7 +26,7 @@ class Policies(_BasePolicyRessource):
         body['tenant_uuid'] = Tenant.autodetect().uuid
         body['uuid'] = self.policy_service.create(**body)
 
-        return body, 200
+        return policy_schema.dump(body), 200
 
     @http.required_acl('auth.policies.read')
     def get(self):
@@ -41,7 +40,7 @@ class Policies(_BasePolicyRessource):
 
         policies = self.policy_service.list(**list_params)
         total = self.policy_service.count(**list_params)
-        return {'items': policies, 'total': total}, 200
+        return {'items': policy_schema.dump(policies, many=True), 'total': total}, 200
 
 
 class Policy(_BasePolicyRessource):
@@ -49,7 +48,7 @@ class Policy(_BasePolicyRessource):
     def get(self, policy_uuid):
         scoping_tenant = Tenant.autodetect()
         policy = self.policy_service.get(policy_uuid, scoping_tenant.uuid)
-        return policy, 200
+        return policy_schema.dump(policy), 200
 
     @http.required_acl('auth.policies.{policy_uuid}.delete')
     def delete(self, policy_uuid):
@@ -61,14 +60,14 @@ class Policy(_BasePolicyRessource):
     def put(self, policy_uuid):
         scoping_tenant = Tenant.autodetect()
         try:
-            body = PolicySchema().load(request.get_json(force=True))
+            body = policy_schema.load(request.get_json(force=True))
         except marshmallow.ValidationError as e:
             for field in e.messages:
                 raise exceptions.InvalidInputException(field)
 
         body['scoping_tenant_uuid'] = scoping_tenant.uuid
         policy = self.policy_service.update(policy_uuid, **body)
-        return policy, 200
+        return policy_schema.dump(policy), 200
 
 
 class PolicyTemplate(_BasePolicyRessource):

--- a/wazo_auth/plugins/http/policies/schemas.py
+++ b/wazo_auth/plugins/http/policies/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -8,6 +8,11 @@ from wazo_auth.schemas import BaseSchema
 
 class PolicySchema(BaseSchema):
 
+    uuid = fields.String(dump_only=True)
+    tenant_uuid = fields.String(dump_only=True)
     name = fields.String(validate=validate.Length(min=1, max=80), required=True)
     description = fields.String(allow_none=True, missing=None)
     acl_templates = fields.List(fields.String(), missing=[])
+
+
+policy_schema = PolicySchema()

--- a/wazo_auth/services/__init__.py
+++ b/wazo_auth/services/__init__.py
@@ -1,6 +1,7 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from .all_users import AllUsersService
 from .authentication import AuthenticationService
 from .email import EmailService
 from .external_auth import ExternalAuthService
@@ -12,6 +13,7 @@ from .token import TokenService
 from .user import UserService, PasswordEncrypter
 
 __all__ = [
+    "AllUsersService",
     "AuthenticationService",
     "EmailService",
     "ExternalAuthService",

--- a/wazo_auth/services/all_users.py
+++ b/wazo_auth/services/all_users.py
@@ -1,0 +1,58 @@
+# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+
+from wazo_auth.database.helpers import commit_or_rollback
+
+logger = logging.getLogger(__name__)
+
+
+class AllUsersService:
+    def __init__(
+        self, group_service, policy_service, tenant_service, all_users_policies
+    ):
+        self._group_service = group_service
+        self._policy_service = policy_service
+        self._tenant_service = tenant_service
+        self._all_users_policies = all_users_policies
+
+    def update_policies(self):
+        top_tenant_uuid = self._tenant_service.find_top_tenant()
+        tenants = self._tenant_service.list_(top_tenant_uuid)
+        tenant_uuids = [tenant['uuid'] for tenant in tenants]
+        logger.debug(
+            'all_users: found %s policies to apply to all users of all tenants',
+            len(self._all_users_policies),
+        )
+        for tenant_uuid in tenant_uuids:
+            logger.debug('all_users: tenant %s: updating policies', tenant_uuid)
+            self.update_policies_for_tenant(tenant_uuid)
+
+        commit_or_rollback()
+
+    def update_policies_for_tenant(self, tenant_uuid):
+        all_users_group = self._group_service.get_all_users_group(tenant_uuid)
+        for name, policy in self._all_users_policies.items():
+            policy_uuid = self._create_policy(
+                tenant_uuid, name, policy, all_users_group
+            )
+            self._associate_policy(tenant_uuid, policy_uuid, all_users_group)
+
+    def _create_policy(self, tenant_uuid, name, policy, all_users_group):
+        logger.debug('all_users: tenant %s: creating policy %s', tenant_uuid, name)
+        return self._policy_service.create(
+            name=name,
+            tenant_uuid=tenant_uuid,
+            description='Automatically created to be applied to all users',
+            **policy,
+        )
+
+    def _associate_policy(self, tenant_uuid, policy_uuid, all_users_group):
+        logger.debug(
+            'all_users: tenant %s: associating policy %s to group %s',
+            tenant_uuid,
+            policy_uuid,
+            all_users_group['uuid'],
+        )
+        self._group_service.add_policy(all_users_group['uuid'], policy_uuid)

--- a/wazo_auth/services/all_users.py
+++ b/wazo_auth/services/all_users.py
@@ -105,6 +105,8 @@ class AllUsersService:
 
     def _delete_policy(self, tenant_uuid, policy_uuid):
         logger.debug(
-            'all_users: tenant %s: deleting policy %s', tenant_uuid, policy_uuid,
+            'all_users: tenant %s: deleting policy %s',
+            tenant_uuid,
+            policy_uuid,
         )
         self._policy_service.delete(policy_uuid, tenant_uuid)

--- a/wazo_auth/services/all_users.py
+++ b/wazo_auth/services/all_users.py
@@ -22,18 +22,18 @@ class AllUsersService:
         tenants = self._tenant_service.list_(top_tenant_uuid)
         tenant_uuids = [tenant['uuid'] for tenant in tenants]
         logger.debug(
-            'all_users: found %s policies to apply to all users of all tenants',
+            'all_users: found %s policies to apply to all users of %s tenants',
             len(self._all_users_policies),
+            len(tenants),
         )
         for tenant_uuid in tenant_uuids:
-            logger.debug('all_users: tenant %s: updating policies', tenant_uuid)
             self.update_policies_for_tenant(tenant_uuid)
 
         commit_or_rollback()
 
     def update_policies_for_tenant(self, tenant_uuid):
         all_users_group = self._group_service.get_all_users_group(tenant_uuid)
-        existing_policies = self._policy_service.list()
+        existing_policies = self._policy_service.list(scoping_tenant_uuid=tenant_uuid)
         existing_policy_names = {
             policy['name']: policy['uuid'] for policy in existing_policies
         }
@@ -53,7 +53,7 @@ class AllUsersService:
                     tenant_uuid, existing_policy_uuid, name, policy, all_users_group
                 )
                 self._associate_policy(
-                    tenant_uuid, existing_policy_uuid, policy, all_users_group
+                    tenant_uuid, existing_policy_uuid, all_users_group
                 )
             else:
                 policy_uuid = self._create_policy(

--- a/wazo_auth/services/policy.py
+++ b/wazo_auth/services/policy.py
@@ -18,6 +18,7 @@ class PolicyService(BaseService):
             raise exceptions.UnknownPolicyException(uuid)
 
     def create(self, **kwargs):
+        kwargs.setdefault('config_managed', False)
         return self._dao.policy.create(**kwargs)
 
     def count(self, scoping_tenant_uuid=None, **kwargs):
@@ -81,6 +82,7 @@ class PolicyService(BaseService):
 
     def update(self, policy_uuid, scoping_tenant_uuid=None, **body):
         args = dict(body)
+        args.setdefault('config_managed', False)
         if scoping_tenant_uuid:
             args['tenant_uuids'] = self._tenant_tree.list_visible_tenants(
                 scoping_tenant_uuid


### PR DESCRIPTION
## tenants: create all-users policies upon tenant creation


## all_users: create missing policies at startup


## all_users: update existing policies at startup


## startup: wait for database to be ready before starting

Why:

* In order to update all_users policies, wazo-auth needs the database.

## all_users: test automatic policy association