### PR TITLE
Pull request for WAZO-2039-group-system-managed

### DIFF
--- a/alembic/versions/31000c80366b_add_system_managed_column_to_group_table.py
+++ b/alembic/versions/31000c80366b_add_system_managed_column_to_group_table.py
@@ -13,7 +13,9 @@ revision = '31000c80366b'
 down_revision = '67ac1f04b6cb'
 
 group_table = sa.sql.table(
-    'auth_group', sa.Column('name'), sa.Column('system_managed'),
+    'auth_group',
+    sa.Column('name'),
+    sa.Column('system_managed'),
 )
 
 

--- a/alembic/versions/31000c80366b_add_system_managed_column_to_group_table.py
+++ b/alembic/versions/31000c80366b_add_system_managed_column_to_group_table.py
@@ -1,0 +1,41 @@
+"""add system_managed column to group table
+
+Revision ID: 31000c80366b
+Revises: 67ac1f04b6cb
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '31000c80366b'
+down_revision = '67ac1f04b6cb'
+
+group_table = sa.sql.table(
+    'auth_group', sa.Column('name'), sa.Column('system_managed'),
+)
+
+
+def upgrade():
+    op.add_column(
+        'auth_group',
+        sa.Column(
+            'system_managed',
+            sa.Boolean,
+            default=False,
+            server_default='false',
+            nullable=False,
+        ),
+    )
+
+    query = (
+        group_table.update()
+        .values(system_managed=True)
+        .where(group_table.c.name.like('wazo-all-users-tenant-%'))
+    )
+    op.execute(query)
+
+
+def downgrade():
+    op.drop_column('auth_group', 'system_managed')

--- a/integration_tests/suite/database/test_db_group.py
+++ b/integration_tests/suite/database/test_db_group.py
@@ -104,7 +104,9 @@ class TestGroupDAO(base.DAOTestCase):
         assert_that(group, has_properties(name=name, tenant_uuid=tenant_uuid))
 
         assert_that(
-            calling(self._group_dao.create).with_args(name, tenant_uuid),
+            calling(self._group_dao.create).with_args(
+                name, tenant_uuid, system_managed=False
+            ),
             raises(exceptions.ConflictException).matching(
                 has_properties(
                     'status_code', 409, 'resource', 'groups', 'details', has_key('name')

--- a/integration_tests/suite/helpers/fixtures/db.py
+++ b/integration_tests/suite/helpers/fixtures/db.py
@@ -161,6 +161,7 @@ def group(**group_args):
         @wraps(decorated)
         def wrapper(self, *args, **kwargs):
             group_args.setdefault('tenant_uuid', self.top_tenant_uuid)
+            group_args.setdefault('system_managed', False)
             group_uuid = self._group_dao.create(**group_args)
             self.session.begin_nested()
             try:

--- a/integration_tests/suite/test_groups.py
+++ b/integration_tests/suite/test_groups.py
@@ -90,7 +90,10 @@ class TestGroups(base.WazoAuthTestCase):
         assert_that(result, has_entries('uuid', group['uuid'], 'name', 'foobaz'))
 
         base.assert_http_error(
-            403, self.client.groups.edit, all_users_group['uuid'], name='another name',
+            403,
+            self.client.groups.edit,
+            all_users_group['uuid'],
+            name='another name',
         )
 
     @fixtures.http.tenant(uuid=base.SUB_TENANT_UUID)

--- a/integration_tests/suite/test_groups.py
+++ b/integration_tests/suite/test_groups.py
@@ -207,6 +207,17 @@ class TestGroups(base.WazoAuthTestCase):
             ),
         )
 
+        # default group should be excluded
+        response = action(system_managed=False)
+        assert_that(
+            response,
+            has_entries(
+                total=3 + NB_DEFAULT_GROUPS,
+                filtered=3,
+                items=contains_inanyorder(one, two, three),
+            ),
+        )
+
     @fixtures.http.tenant(uuid=base.SUB_TENANT_UUID)
     @fixtures.http.group(name='one', tenant_uuid=base.SUB_TENANT_UUID)
     @fixtures.http.group(name='two', tenant_uuid=base.SUB_TENANT_UUID)

--- a/integration_tests/suite/test_groups.py
+++ b/integration_tests/suite/test_groups.py
@@ -22,13 +22,16 @@ class TestGroups(base.WazoAuthTestCase):
     invalid_bodies = [{}, {'name': None}, {'name': 42}, {'not name': 'foobar'}]
 
     @fixtures.http.group(name='foobar')
-    def test_delete(self, foobar):
+    @fixtures.http.group(name='all-users-group', system_managed=True)
+    def test_delete(self, all_users_group, foobar):
         base.assert_http_error(404, self.client.groups.delete, UNKNOWN_UUID)
 
         with self.client_in_subtenant() as (client, _, __):
             base.assert_http_error(404, client.groups.delete, foobar['uuid'])
 
         base.assert_no_error(self.client.groups.delete, foobar['uuid'])
+
+        base.assert_http_error(403, self.client.groups.delete, all_users_group['uuid'])
 
     @fixtures.http.group(name='foobar')
     def test_get(self, foobar):
@@ -59,7 +62,8 @@ class TestGroups(base.WazoAuthTestCase):
 
     @fixtures.http.group(name='foobar')
     @fixtures.http.group(name='duplicate')
-    def test_put(self, duplicate, group):
+    @fixtures.http.group(name='all-users-group', system_managed=True)
+    def test_put(self, all_users_group, duplicate, group):
         base.assert_http_error(
             404, self.client.groups.edit, UNKNOWN_UUID, name='foobaz'
         )
@@ -84,6 +88,10 @@ class TestGroups(base.WazoAuthTestCase):
 
         result = self.client.groups.get(group['uuid'])
         assert_that(result, has_entries('uuid', group['uuid'], 'name', 'foobaz'))
+
+        base.assert_http_error(
+            403, self.client.groups.edit, all_users_group['uuid'], name='another name',
+        )
 
     @fixtures.http.tenant(uuid=base.SUB_TENANT_UUID)
     @fixtures.http.group(name='one', tenant_uuid=base.SUB_TENANT_UUID)

--- a/integration_tests/suite/test_user_group.py
+++ b/integration_tests/suite/test_user_group.py
@@ -144,7 +144,10 @@ class TestUserGroupAssociation(base.WazoAuthTestCase):
         assert_no_error(action, group['uuid'], user2['uuid'])  # Twice
 
         assert_http_error(
-            403, action, all_users_group['uuid'], user2['uuid'],
+            403,
+            action,
+            all_users_group['uuid'],
+            user2['uuid'],
         )
 
         result = self.client.groups.get_users(group['uuid'])
@@ -176,7 +179,10 @@ class TestUserGroupAssociation(base.WazoAuthTestCase):
         assert_no_error(action, group['uuid'], user1['uuid'])  # Twice
 
         assert_http_error(
-            403, action, all_users_group['uuid'], user2['uuid'],
+            403,
+            action,
+            all_users_group['uuid'],
+            user2['uuid'],
         )
 
         result = self.client.groups.get_users(group['uuid'])

--- a/integration_tests/suite/test_user_group.py
+++ b/integration_tests/suite/test_user_group.py
@@ -131,7 +131,8 @@ class TestUserGroupAssociation(base.WazoAuthTestCase):
     @fixtures.http.user_register()
     @fixtures.http.user_register()
     @fixtures.http.group()
-    def test_delete(self, group, user1, user2):
+    @fixtures.http.group(name='all-users-group', system_managed=True)
+    def test_delete(self, all_users_group, group, user1, user2):
         action = self.client.groups.remove_user
 
         self.client.groups.add_user(group['uuid'], user1['uuid'])
@@ -141,6 +142,10 @@ class TestUserGroupAssociation(base.WazoAuthTestCase):
         assert_http_error(404, action, group['uuid'], UNKNOWN_UUID)
         assert_no_error(action, group['uuid'], user2['uuid'])
         assert_no_error(action, group['uuid'], user2['uuid'])  # Twice
+
+        assert_http_error(
+            403, action, all_users_group['uuid'], user2['uuid'],
+        )
 
         result = self.client.groups.get_users(group['uuid'])
         assert_that(result, has_entries('items', contains_inanyorder(user1)))
@@ -161,13 +166,18 @@ class TestUserGroupAssociation(base.WazoAuthTestCase):
     @fixtures.http.user_register()
     @fixtures.http.user_register()
     @fixtures.http.group()
-    def test_put(self, group, user1, user2):
+    @fixtures.http.group(name='all-users-group', system_managed=True)
+    def test_put(self, all_users_group, group, user1, user2):
         action = self.client.groups.add_user
 
         assert_http_error(404, action, UNKNOWN_UUID, user1['uuid'])
         assert_http_error(404, action, group['uuid'], UNKNOWN_UUID)
         assert_no_error(action, group['uuid'], user1['uuid'])
         assert_no_error(action, group['uuid'], user1['uuid'])  # Twice
+
+        assert_http_error(
+            403, action, all_users_group['uuid'], user2['uuid'],
+        )
 
         result = self.client.groups.get_users(group['uuid'])
         assert_that(result, has_entries('items', contains_inanyorder(user1)))

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -106,6 +106,9 @@ class Group(Base):
     tenant_uuid = Column(
         String(38), ForeignKey('auth_tenant.uuid', ondelete='CASCADE'), nullable=False
     )
+    system_managed = Column(
+        Boolean, nullable=False, default=False, server_default='false'
+    )
 
 
 class GroupPolicy(Base):

--- a/wazo_auth/database/queries/filters.py
+++ b/wazo_auth/database/queries/filters.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import and_, or_, text
@@ -70,6 +70,7 @@ group_strict_filter = StrictFilter(
     ('uuid', Group.uuid, str),
     ('name', Group.name, None),
     ('user_uuid', UserGroup.user_uuid, str),
+    ('system_managed', Group.system_managed, bool),
 )
 policy_strict_filter = StrictFilter(
     ('uuid', Policy.uuid, str),

--- a/wazo_auth/database/queries/group.py
+++ b/wazo_auth/database/queries/group.py
@@ -193,3 +193,18 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         result = self.session.query(UserGroup).filter(filter_).delete()
         self.session.flush()
         return result
+
+    def is_system_managed(self, uuid, tenant_uuids=None):
+        filter_ = Group.uuid == str(uuid)
+        if tenant_uuids is not None:
+            if not tenant_uuids:
+                raise exceptions.UnknownGroupException(uuid)
+
+            filter_ = and_(filter_, Group.tenant_uuid.in_(tenant_uuids))
+
+        result = self.session.query(Group).filter(filter_).first()
+
+        if not result:
+            raise exceptions.UnknownGroupException(uuid)
+
+        return result.system_managed

--- a/wazo_auth/database/queries/group.py
+++ b/wazo_auth/database/queries/group.py
@@ -100,8 +100,8 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             .count()
         )
 
-    def create(self, name, tenant_uuid, **ignored):
-        group = Group(name=name, tenant_uuid=tenant_uuid)
+    def create(self, name, tenant_uuid, system_managed, **ignored):
+        group = Group(name=name, tenant_uuid=tenant_uuid, system_managed=system_managed)
         self.session.add(group)
         try:
             self.session.flush()

--- a/wazo_auth/database/queries/group.py
+++ b/wazo_auth/database/queries/group.py
@@ -152,7 +152,12 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         query = self._paginator.update_query(query, **kwargs)
 
         return [
-            {'uuid': group.uuid, 'name': group.name, 'tenant_uuid': group.tenant_uuid}
+            {
+                'uuid': group.uuid,
+                'name': group.name,
+                'tenant_uuid': group.tenant_uuid,
+                'system_managed': group.system_managed,
+            }
             for group in query.all()
         ]
 

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unidecode import unidecode
@@ -114,6 +114,13 @@ class UnknownGroupException(APIException):
         msg = 'No such group: "{}"'.format(group_uuid)
         details = {'uuid': str(group_uuid)}
         super().__init__(404, msg, 'unknown-group', details, 'groups')
+
+
+class SystemGroupForbidden(APIException):
+    def __init__(self, group_uuid):
+        msg = 'Forbidden group modification: "{}"'.format(group_uuid)
+        details = {'uuid': str(group_uuid)}
+        super().__init__(403, msg, 'forbidden-group', details, 'groups')
 
 
 class UnknownTenantException(APIException):

--- a/wazo_auth/plugins/http/groups/api.yml
+++ b/wazo_auth/plugins/http/groups/api.yml
@@ -190,7 +190,10 @@ definitions:
         type: string
       tenant_uuid:
         type: string
+      system_managed:
+        type: boolean
     required:
     - uuid
     - name
+    - system_managed
     - tenant_uuid

--- a/wazo_auth/schemas.py
+++ b/wazo_auth/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import Schema, fields, pre_load, post_dump, EXCLUDE
@@ -81,9 +81,10 @@ class ExternalListSchema(BaseListSchema):
 
 
 class GroupListSchema(BaseListSchema):
-    sort_columns = ['name', 'uuid']
+    system_managed = fields.Boolean()
+    sort_columns = ['name', 'uuid', 'system_managed']
     default_sort_column = 'name'
-    searchable_columns = ['uuid', 'name', 'user_uuid']
+    searchable_columns = ['uuid', 'name', 'user_uuid', 'system_managed']
 
 
 class UserGroupListSchema(BaseListSchema):

--- a/wazo_auth/services/group.py
+++ b/wazo_auth/services/group.py
@@ -26,6 +26,7 @@ class GroupService(BaseService):
         return self._dao.group.count_users(group_uuid, **kwargs)
 
     def create(self, **kwargs):
+        kwargs.setdefault('system_managed', False)
         uuid = self._dao.group.create(**kwargs)
         return dict(uuid=uuid, **kwargs)
 

--- a/wazo_auth/services/group.py
+++ b/wazo_auth/services/group.py
@@ -32,6 +32,8 @@ class GroupService(BaseService):
 
     def delete(self, group_uuid, scoping_tenant_uuid):
         tenant_uuids = self._tenant_tree.list_visible_tenants(scoping_tenant_uuid)
+        if self._dao.group.is_system_managed(group_uuid, tenant_uuids):
+            raise exceptions.SystemGroupForbidden(group_uuid)
         return self._dao.group.delete(group_uuid, tenant_uuids=tenant_uuids)
 
     def get(self, group_uuid, scoping_tenant_uuid):
@@ -106,6 +108,8 @@ class GroupService(BaseService):
             raise exceptions.UnknownUserException(user_uuid)
 
     def update(self, group_uuid, **kwargs):
+        if self._dao.group.is_system_managed(group_uuid):
+            raise exceptions.SystemGroupForbidden(group_uuid)
         return self._dao.group.update(group_uuid, **kwargs)
 
     def assert_group_in_subtenant(self, scoping_tenant_uuid, uuid):

--- a/wazo_auth/services/group.py
+++ b/wazo_auth/services/group.py
@@ -10,6 +10,12 @@ class GroupService(BaseService):
         return self._dao.group.add_policy(group_uuid, policy_uuid)
 
     def add_user(self, group_uuid, user_uuid):
+        if self._dao.group.is_system_managed(group_uuid):
+            raise exceptions.SystemGroupForbidden(group_uuid)
+
+        return self._dao.group.add_user(group_uuid, user_uuid)
+
+    def add_user_from_system(self, group_uuid, user_uuid):
         return self._dao.group.add_user(group_uuid, user_uuid)
 
     def count(self, scoping_tenant_uuid, recurse=False, **kwargs):
@@ -97,6 +103,9 @@ class GroupService(BaseService):
             raise exceptions.UnknownPolicyException(policy_uuid)
 
     def remove_user(self, group_uuid, user_uuid):
+        if self._dao.group.is_system_managed(group_uuid):
+            raise exceptions.SystemGroupForbidden(group_uuid)
+
         nb_deleted = self._dao.group.remove_user(group_uuid, user_uuid)
         if nb_deleted:
             return

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -92,7 +92,7 @@ class TenantService(BaseService):
         self._bus_publisher.publish(event)
 
         all_users_group = self._group_service.create(
-            name=f'wazo-all-users-tenant-{uuid}', tenant_uuid=uuid
+            name=f'wazo-all-users-tenant-{uuid}', tenant_uuid=uuid, system_managed=True
         )
 
         for name, policy in self._all_users_policies.items():

--- a/wazo_auth/services/user.py
+++ b/wazo_auth/services/user.py
@@ -120,7 +120,9 @@ class UserService(BaseService):
         wazo_all_users_group = self._group_service.get_all_users_group(
             kwargs['tenant_uuid']
         )
-        self._group_service.add_user(wazo_all_users_group['uuid'], user['uuid'])
+        self._group_service.add_user_from_system(
+            wazo_all_users_group['uuid'], user['uuid']
+        )
 
         return user
 

--- a/wazo_auth/tests/test_services.py
+++ b/wazo_auth/tests/test_services.py
@@ -164,9 +164,10 @@ class TestGroupService(BaseServiceTestCase):
         )
 
     def test_remove_user(self):
-        def when(nb_deleted, group_exists=True, user_exists=True):
+        def when(nb_deleted, group_exists=True, user_exists=True, system_managed=False):
             self.group_dao.remove_user.return_value = nb_deleted
             self.group_dao.exists.return_value = group_exists
+            self.group_dao.is_system_managed.return_value = system_managed
             self.user_dao.exists.return_value = user_exists
 
         when(nb_deleted=0, group_exists=False)
@@ -179,6 +180,12 @@ class TestGroupService(BaseServiceTestCase):
         assert_that(
             calling(self.service.remove_user).with_args(s.group_uuid, s.user_uuid),
             raises(exceptions.UnknownUserException),
+        )
+
+        when(nb_deleted=0, system_managed=True)
+        assert_that(
+            calling(self.service.remove_user).with_args(s.group_uuid, s.user_uuid),
+            raises(exceptions.SystemGroupForbidden),
         )
 
         when(nb_deleted=0)


### PR DESCRIPTION
## groups: add property system_managed


## groups: restrict modification of system managed groups

Why:

* If a system managed group is deleted, wazo-auth will crash when
starting
