### PR TITLE
fix corrupt acl

### DIFF
--- a/alembic/versions/40d8f37d7096_rename_acl_template_table_to_access.py
+++ b/alembic/versions/40d8f37d7096_rename_acl_template_table_to_access.py
@@ -1,7 +1,7 @@
 """rename_acl_template_table_to_access
 
 Revision ID: 40d8f37d7096
-Revises: 17ce2e46c43e
+Revises: d779d0640bd7
 
 """
 
@@ -9,7 +9,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '40d8f37d7096'
-down_revision = '17ce2e46c43e'
+down_revision = 'd779d0640bd7'
 
 
 def upgrade():

--- a/alembic/versions/d779d0640bd7_fix_corrupt_acl.py
+++ b/alembic/versions/d779d0640bd7_fix_corrupt_acl.py
@@ -1,0 +1,59 @@
+"""fix-corrupt-acl
+
+Revision ID: d779d0640bd7
+Revises: 17ce2e46c43e
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd779d0640bd7'
+down_revision = '17ce2e46c43e'
+
+acl_template_tbl = sa.sql.table(
+    'auth_acl_template',
+    sa.Column('id'),
+    sa.Column('template'),
+    sa.Column('count'),
+)
+
+
+def remove_duplicate_template(template_name):
+    first_skipped = False
+    query = sa.sql.select([acl_template_tbl.c.id]).where(
+        acl_template_tbl.c.template == template_name
+    )
+    duplicates = op.get_bind().execute(query)
+    for template in duplicates:
+        if not first_skipped:
+            first_skipped = True
+            continue
+        query = acl_template_tbl.delete().where(acl_template_tbl.c.id == template.id)
+        op.execute(query)
+
+
+def upgrade():
+    count_query = (
+        sa.sql.select(
+            [
+                sa.func.count(acl_template_tbl.c.id).label('count'),
+                acl_template_tbl.c.template.label('template'),
+            ]
+        )
+        .group_by(acl_template_tbl.c.template)
+        .alias('count_query')
+    )
+    query = (
+        sa.sql.select([count_query.c.count, count_query.c.template])
+        .select_from(count_query)
+        .where(count_query.c.count > 1)
+    )
+    templates = op.get_bind().execute(query)
+    for template in templates:
+        remove_duplicate_template(template.template)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
reason: for an unknown reason, some acl_template are duplicate and cause
issue on next migration scripts

To test: There is a snapshot on daily-wazo-upgrade-rolling-dev with the issue