### PR TITLE
WAZO-2128 session: always check that user_uuid is a valid uuid

### DIFF
--- a/integration_tests/suite/database/test_db_session.py
+++ b/integration_tests/suite/database/test_db_session.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -10,6 +10,7 @@ from hamcrest import (
     equal_to,
     empty,
     has_entries,
+    has_items,
 )
 from ..helpers import base, fixtures
 
@@ -61,6 +62,17 @@ class TestSessionDAO(base.DAOTestCase):
 
         result = self._session_dao.list_(user_uuid=token_1['auth_id'])
         assert_that(result, contains(has_entries(uuid=token_1['session_uuid'])))
+
+    @fixtures.db.token(auth_id='not-uuid-id', session_uuid=SESSION_UUID_1)
+    @fixtures.db.token(auth_id='', session_uuid=SESSION_UUID_1)
+    def test_list_whith_no_uuid_auth_id(self, token_1, token_2):
+        session_uuid = token_1['session_uuid']
+        result = self._session_dao.list_()
+        assert_that(result, has_items(has_entries(uuid=session_uuid, user_uuid=None)))
+
+        session_uuid = token_2['session_uuid']
+        result = self._session_dao.list_()
+        assert_that(result, has_items(has_entries(uuid=session_uuid, user_uuid=None)))
 
     @fixtures.db.tenant(uuid=TENANT_UUID_1)
     @fixtures.db.token(session_uuid=SESSION_UUID_2)

--- a/integration_tests/suite/test_password_reset.py
+++ b/integration_tests/suite/test_password_reset.py
@@ -7,6 +7,8 @@ from hamcrest import (
     assert_that,
     contains_inanyorder,
     contains_string,
+    has_entries,
+    has_items,
     not_,
 )
 
@@ -72,3 +74,10 @@ class TestResetPassword(WazoAuthTestCase):
 
         logs = self.service_logs('auth', since=time_start)
         assert_that(logs, not_(contains_string(new_password)))
+
+    @fixtures.http.user(username='foo', email_address='foo@example.com')
+    def test_password_reset_do_not_create_session_with_invalid_user_uuid(self, foo):
+        self.client.users.reset_password(username='foo')
+
+        response = self.client.sessions.list()
+        assert_that(response['items'], has_items(has_entries(user_uuid=None)))

--- a/wazo_auth/database/queries/session.py
+++ b/wazo_auth/database/queries/session.py
@@ -5,6 +5,7 @@ from sqlalchemy import text, and_
 
 from .base import BaseDAO, PaginatorMixin
 from ..models import Session, Token
+from ...helpers import is_uuid
 
 
 class SessionDAO(PaginatorMixin, BaseDAO):
@@ -27,12 +28,12 @@ class SessionDAO(PaginatorMixin, BaseDAO):
 
         return [
             {
-                'uuid': result.Session.uuid,
-                'mobile': result.Session.mobile,
-                'tenant_uuid': result.Session.tenant_uuid,
-                'user_uuid': result.Token.auth_id,
+                'uuid': r.Session.uuid,
+                'mobile': r.Session.mobile,
+                'tenant_uuid': r.Session.tenant_uuid,
+                'user_uuid': r.Token.auth_id if is_uuid(r.Token.auth_id) else None,
             }
-            for result in query.all()
+            for r in query.all()
         ]
 
     def count(self, tenant_uuids=None, **kwargs):

--- a/wazo_auth/helpers.py
+++ b/wazo_auth/helpers.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+import uuid
 import time
 
 from functools import partial
@@ -56,3 +57,12 @@ class LocalTokenRenewer:
 
     def _need_new_token(self):
         return not self._token or time.time() > self._renew_time
+
+
+def is_uuid(value):
+    try:
+        uuid_obj = uuid.UUID(value, version=4)
+    except ValueError:
+        return False
+
+    return str(uuid_obj) == value

--- a/wazo_auth/services/token.py
+++ b/wazo_auth/services/token.py
@@ -20,6 +20,7 @@ from ..exceptions import (
     MissingTenantTokenException,
     UnknownTokenException,
 )
+from ..helpers import is_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +129,10 @@ class TokenService(BaseService):
         )
         token = Token(token_uuid, session_uuid=session_uuid, **token_payload)
 
-        event = SessionCreatedEvent(session_uuid, user_uuid=auth_id, **session_payload)
+        user_uuid = auth_id if is_uuid(auth_id) else None
+        event = SessionCreatedEvent(
+            session_uuid, user_uuid=user_uuid, **session_payload
+        )
         self._bus_publisher.publish(event)
 
         return token


### PR DESCRIPTION
reason: user_uuid is based on auth_id which can be a string of anything
(ex: the token created to reset password have the value "wazo-auth")
if it's not a valid uuid, then we return None