### PR TITLE
tenant slug: migration: add slug to the slug set

### DIFF
--- a/alembic/versions/9b80db8b7860_add_tenant_slug.py
+++ b/alembic/versions/9b80db8b7860_add_tenant_slug.py
@@ -51,6 +51,7 @@ def upgrade():
                 if slug not in slugs:
                     break
 
+        slugs.add(slug)
         op.execute(
             tenant_tbl.update()
             .values(slug=slug)


### PR DESCRIPTION
there's no need to check if a new slug is in the slug set if we never add them
to the set to begin with.