### PR TITLE
Pull request for WAZO-2317-shared-default-policies

### DIFF
--- a/integration_tests/assets/etc/wazo-auth/conf.d/asset.base.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/asset.base.yml
@@ -13,7 +13,10 @@ backend_policies:
 password_reset_email_template: '/var/lib/wazo-auth/templates/raw_password_reset_email.jinja'
 email_confirmation_get_response_body_template: '/var/lib/wazo-auth/templates/email_confirmation_get_body.jinja'
 email_confirmation_get_mimetype: 'text/x-test'
+
 all_users_policies:
+  wazo-all-users-policy: true
+default_policies:
   wazo-all-users-policy:
     acl:
       - integration_tests.access

--- a/integration_tests/suite/helpers/constants.py
+++ b/integration_tests/suite/helpers/constants.py
@@ -8,5 +8,10 @@ UNKNOWN_TENANT = '55ee61f3-c4a5-427c-9f40-9d5c33466240'
 DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@localhost:{port}')
 ISO_DATETIME = '%Y-%m-%dT%H:%M:%S.%f'
 NB_DEFAULT_GROUPS = 1
-NB_DEFAULT_POLICIES = 1
-DEFAULT_POLICY_SLUG = 'wazo-all-users-policy'
+ALL_USERS_POLICY_SLUG = 'wazo-all-users-policy'
+DEFAULT_POLICIES_SLUG = [
+    ALL_USERS_POLICY_SLUG,
+    'wazo_default_admin_policy',
+    'wazo_default_user_policy',
+]
+NB_DEFAULT_POLICIES = len(DEFAULT_POLICIES_SLUG)

--- a/integration_tests/suite/test_group_policy.py
+++ b/integration_tests/suite/test_group_policy.py
@@ -12,7 +12,7 @@ from hamcrest import (
     not_,
 )
 from .helpers import base, fixtures
-from .helpers.constants import UNKNOWN_UUID, DEFAULT_POLICY_SLUG
+from .helpers.constants import UNKNOWN_UUID, ALL_USERS_POLICY_SLUG
 
 
 class TestGroupPolicyAssociation(base.WazoAuthTestCase):
@@ -159,7 +159,7 @@ class TestGroupPolicyAssociation(base.WazoAuthTestCase):
         assert_that(token_data, has_entries('acl', has_items('foobar')))
 
     def test_default_policies_are_updated_at_startup(self):
-        policy = self.client.policies.list(slug=DEFAULT_POLICY_SLUG)['items'][0]
+        policy = self.client.policies.list(slug=ALL_USERS_POLICY_SLUG)['items'][0]
         policy_without_acl = dict(policy)
         policy_without_acl['acl'] = []
         self.client.policies.edit(policy['uuid'], **policy_without_acl)
@@ -200,7 +200,7 @@ class TestGroupPolicyAssociation(base.WazoAuthTestCase):
     def test_policies_are_created_and_associated_at_startup(self):
         group_name = f'wazo-all-users-tenant-{self.top_tenant_uuid}'
         group = self.client.groups.list(name=group_name)['items'][0]
-        policy = self.client.policies.list(slug=DEFAULT_POLICY_SLUG)['items'][0]
+        policy = self.client.policies.list(slug=ALL_USERS_POLICY_SLUG)['items'][0]
         policy_without_acl = dict(policy)
         policy_without_acl['acl'] = []
         self.client.policies.edit(policy['uuid'], **policy_without_acl)

--- a/integration_tests/suite/test_group_policy.py
+++ b/integration_tests/suite/test_group_policy.py
@@ -158,7 +158,7 @@ class TestGroupPolicyAssociation(base.WazoAuthTestCase):
         token_data = user_client.token.new('wazo_user', expiration=5)
         assert_that(token_data, has_entries('acl', has_items('foobar')))
 
-    def test_all_users_policies_are_updated_at_startup(self):
+    def test_default_policies_are_updated_at_startup(self):
         policy = self.client.policies.list(slug=DEFAULT_POLICY_SLUG)['items'][0]
         policy_without_acl = dict(policy)
         policy_without_acl['acl'] = []
@@ -169,9 +169,37 @@ class TestGroupPolicyAssociation(base.WazoAuthTestCase):
         policy = self.client.policies.get(policy['uuid'])
         assert_that(policy, has_entries(acl=has_item('integration_tests.access')))
 
-    def test_all_users_policies_are_associated_at_startup(self):
-        policy_name = f'wazo-all-users-tenant-{self.top_tenant_uuid}'
-        group = self.client.groups.list(name=policy_name)['items'][0]
+    @fixtures.http.group()
+    @fixtures.http.policy(name='kept', acl=['kept'], config_managed=True)
+    def test_default_policies_are_not_deleted_when_associated(self, group, policy):
+        self.client.groups.add_policy(group['uuid'], policy['uuid'])
+
+        self.restart_auth()
+
+        policies = self.client.groups.get_policies(group['uuid'])['items']
+        assert_that(policies, has_item(has_entries(uuid=policy['uuid'])))
+
+        policy = self.client.policies.get(policy['uuid'])
+        assert_that(policy, has_entries(uuid=policy['uuid']))
+
+    @fixtures.http.policy(name='to-be-removed', acl=['removed'], config_managed=True)
+    def test_policies_are_deleted_at_startup(self, policy):
+        group_name = f'wazo-all-users-tenant-{self.top_tenant_uuid}'
+        group = self.client.groups.list(name=group_name)['items'][0]
+        self.client.groups.add_policy(group['uuid'], policy['uuid'])
+
+        self.restart_auth()
+
+        # all_users_policies are dissociated
+        policies = self.client.groups.get_policies(group['uuid'])['items']
+        assert_that(policies, not_(has_item(has_entries(uuid=policy['uuid']))))
+
+        # default_policies are removed
+        base.assert_http_error(404, self.client.policies.get, policy['uuid'])
+
+    def test_policies_are_created_and_associated_at_startup(self):
+        group_name = f'wazo-all-users-tenant-{self.top_tenant_uuid}'
+        group = self.client.groups.list(name=group_name)['items'][0]
         policy = self.client.policies.list(slug=DEFAULT_POLICY_SLUG)['items'][0]
         policy_without_acl = dict(policy)
         policy_without_acl['acl'] = []
@@ -180,6 +208,11 @@ class TestGroupPolicyAssociation(base.WazoAuthTestCase):
 
         self.restart_auth()
 
+        # default_policies are created
+        policy = self.client.policies.get(policy['uuid'])
+        assert_that(policy, has_entries(uuid=policy['uuid']))
+
+        # all_users_policies are associated
         group_policies = self.client.groups.get_policies(group['uuid'])['items']
         assert_that(
             group_policies,
@@ -190,29 +223,3 @@ class TestGroupPolicyAssociation(base.WazoAuthTestCase):
                 )
             ),
         )
-
-    @fixtures.http.policy(name='to-be-removed', acl=['removed'], config_managed=True)
-    def test_all_users_policies_are_deleted_at_startup(self, policy):
-        policy_name = f'wazo-all-users-tenant-{self.top_tenant_uuid}'
-        group = self.client.groups.list(name=policy_name)['items'][0]
-        self.client.groups.add_policy(group['uuid'], policy['uuid'])
-
-        self.restart_auth()
-
-        policies = self.client.groups.get_policies(group['uuid'])['items']
-        assert_that(policies, not_(has_item(has_entries(uuid=policy['uuid']))))
-
-        base.assert_http_error(404, self.client.policies.get, policy['uuid'])
-
-    @fixtures.http.group()
-    @fixtures.http.policy(name='kept', acl=['kept'], config_managed=True)
-    def test_policies_are_not_deleted_if_associated_at_startup(self, group, policy):
-        self.client.groups.add_policy(group['uuid'], policy['uuid'])
-
-        self.restart_auth()
-
-        policies = self.client.groups.get_policies(group['uuid'])['items']
-        assert_that(policies, has_item(has_entries(uuid=policy['uuid'])))
-
-        policy = self.client.policies.get(policy['uuid'])
-        assert_that(policy, has_entries(uuid=policy['uuid']))

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -353,7 +353,10 @@ class TestTenantPolicyAssociation(WazoAuthTestCase):
 
         result = action()
         expected = contains_inanyorder(
-            *[has_entries(name=n) for n in ('foo', 'bar', 'baz', *DEFAULT_POLICIES_SLUG)]
+            *[
+                has_entries(name=n)
+                for n in ('foo', 'bar', 'baz', *DEFAULT_POLICIES_SLUG)
+            ]
         )
         assert_that(
             result,

--- a/wazo_auth/database/queries/filters.py
+++ b/wazo_auth/database/queries/filters.py
@@ -79,6 +79,7 @@ policy_strict_filter = StrictFilter(
     ('user_uuid', UserPolicy.user_uuid, str),
     ('group_uuid', GroupPolicy.group_uuid, str),
     ('tenant_uuid', Policy.tenant_uuid, str),
+    ('system_managed', Policy.config_managed, bool),
 )
 refresh_token_strict_filter = StrictFilter(
     ('client_id', RefreshToken.client_id, None),

--- a/wazo_auth/database/queries/policy.py
+++ b/wazo_auth/database/queries/policy.py
@@ -93,7 +93,7 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                 or_(
                     Policy.tenant_uuid.in_(tenant_uuids),
                     Policy.config_managed.is_(True),
-                )
+                ),
             )
 
         return self.session.query(Policy).filter(filter_).count()
@@ -156,7 +156,7 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                 or_(
                     Policy.tenant_uuid.in_(tenant_uuids),
                     Policy.config_managed.is_(True),
-                )
+                ),
             )
 
         query = (

--- a/wazo_auth/database/queries/policy.py
+++ b/wazo_auth/database/queries/policy.py
@@ -4,7 +4,14 @@
 import random
 import re
 import string
-from sqlalchemy import and_, distinct, exc, func, text
+from sqlalchemy import (
+    and_,
+    distinct,
+    exc,
+    func,
+    or_,
+    text,
+)
 from .base import BaseDAO, PaginatorMixin
 from . import filters
 from ..models import (
@@ -81,7 +88,13 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         filter_ = self.new_search_filter(search=search)
 
         if tenant_uuids is not None:
-            filter_ = and_(filter_, Policy.tenant_uuid.in_(tenant_uuids))
+            filter_ = and_(
+                filter_,
+                or_(
+                    Policy.tenant_uuid.in_(tenant_uuids),
+                    Policy.config_managed.is_(True),
+                )
+            )
 
         return self.session.query(Policy).filter(filter_).count()
 
@@ -138,7 +151,13 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         filter_ = and_(strict_filter, search_filter)
 
         if tenant_uuids is not None:
-            filter_ = and_(filter_, Policy.tenant_uuid.in_(tenant_uuids))
+            filter_ = and_(
+                filter_,
+                or_(
+                    Policy.tenant_uuid.in_(tenant_uuids),
+                    Policy.config_managed.is_(True),
+                )
+            )
 
         query = (
             self.session.query(
@@ -161,6 +180,11 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
         policies = []
         for policy in query.all():
+            tenant_uuid = policy.tenant_uuid
+            if policy.config_managed:
+                if tenant_uuids and tenant_uuid not in tenant_uuids:
+                    tenant_uuid = tenant_uuids[0]
+
             if policy.acl == [None]:
                 acl = []
             else:
@@ -172,7 +196,7 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                 'slug': policy.slug,
                 'description': policy.description,
                 'acl': acl,
-                'tenant_uuid': policy.tenant_uuid,
+                'tenant_uuid': tenant_uuid,
                 'config_managed': policy.config_managed,
             }
             policies.append(body)
@@ -180,9 +204,17 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         return policies
 
     def list_(self, **kwargs):
+        tenant_uuid = kwargs.pop('tenant_uuid', None)
+        if tenant_uuid:
+            tenant_uuid = str(tenant_uuid)
+            tenant_filter = or_(
+                Policy.tenant_uuid == tenant_uuid,
+                Policy.config_managed.is_(True),
+            )
+
         search_filter = self.new_search_filter(**kwargs)
         strict_filter = self.new_strict_filter(**kwargs)
-        filter_ = and_(strict_filter, search_filter)
+        filter_ = and_(tenant_filter, strict_filter, search_filter)
 
         query = self.session.query(Policy).filter(filter_).group_by(Policy)
         query = self._paginator.update_query(query, **kwargs)
@@ -192,7 +224,7 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                 'uuid': policy.uuid,
                 'name': policy.name,
                 'slug': policy.slug,
-                'tenant_uuid': policy.tenant_uuid,
+                'tenant_uuid': tenant_uuid or policy.tenant_uuid,
             }
             for policy in query.all()
         ]

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -5,7 +5,7 @@ import random
 import string
 import re
 
-from sqlalchemy import and_, exc, text
+from sqlalchemy import and_, exc, text, or_
 from wazo_auth import schemas
 from .base import BaseDAO, PaginatorMixin
 from ..models import Address, Policy, Tenant, User
@@ -41,7 +41,10 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         return self.session.query(Tenant).filter(filter_).count()
 
     def count_policies(self, tenant_uuid, filtered=False, **kwargs):
-        filter_ = Policy.tenant_uuid == str(tenant_uuid)
+        filter_ = or_(
+            Policy.tenant_uuid == str(tenant_uuid),
+            Policy.config_managed.is_(True),
+        )
 
         if filtered is not False:
             strict_filter = filters.policy_strict_filter.new_filter(**kwargs)

--- a/wazo_auth/plugins/http/group_policy/http.py
+++ b/wazo_auth/plugins/http/group_policy/http.py
@@ -54,16 +54,27 @@ class GroupPolicies(_BaseResource):
         except marshmallow.ValidationError as e:
             raise exceptions.InvalidListParamException(e.messages)
 
-        policies = self.group_service.list_policies(group_uuid, **list_params)
+        tenant_uuids = self.group_service.build_tenant_list(scoping_tenant.uuid)
+        policies = self.group_service.list_policies(
+            group_uuid,
+            tenant_uuids=tenant_uuids,
+            **list_params,
+        )
+        total = self.group_service.count_policies(
+            group_uuid,
+            filtered=False,
+            **list_params,
+        )
+        filtered = self.group_service.count_policies(
+            group_uuid,
+            filtered=True,
+            **list_params,
+        )
         return (
             {
                 'items': policy_full_schema.dump(policies, many=True),
-                'total': self.group_service.count_policies(
-                    group_uuid, filtered=False, **list_params
-                ),
-                'filtered': self.group_service.count_policies(
-                    group_uuid, filtered=True, **list_params
-                ),
+                'total': total,
+                'filtered': filtered,
             },
             200,
         )

--- a/wazo_auth/schemas.py
+++ b/wazo_auth/schemas.py
@@ -104,6 +104,7 @@ class PolicyListSchema(BaseListSchema):
         'user_uuid',
         'group_uuid',
         'tenant_uuid',
+        'system_managed',
     ]
 
 

--- a/wazo_auth/services/all_users.py
+++ b/wazo_auth/services/all_users.py
@@ -10,7 +10,11 @@ logger = logging.getLogger(__name__)
 
 class AllUsersService:
     def __init__(
-        self, group_service, policy_service, tenant_service, all_users_policies,
+        self,
+        group_service,
+        policy_service,
+        tenant_service,
+        all_users_policies,
     ):
         self._group_service = group_service
         self._policy_service = policy_service
@@ -63,10 +67,7 @@ class AllUsersService:
             self._dissociate_policy(tenant_uuid, policy['uuid'], all_users_group)
 
     def _find_policy(self, slug):
-        policies = self._policy_service.list(
-            slug=slug,
-            scoping_tenant_uuid=None
-        )
+        policies = self._policy_service.list(slug=slug, scoping_tenant_uuid=None)
         for policy in policies:
             return policy
 

--- a/wazo_auth/services/all_users.py
+++ b/wazo_auth/services/all_users.py
@@ -10,17 +10,11 @@ logger = logging.getLogger(__name__)
 
 class AllUsersService:
     def __init__(
-        self,
-        group_service,
-        policy_service,
-        tenant_service,
-        default_policies,
-        all_users_policies,
+        self, group_service, policy_service, tenant_service, all_users_policies,
     ):
         self._group_service = group_service
         self._policy_service = policy_service
         self._tenant_service = tenant_service
-        self._default_policies = default_policies
         self._all_users_policies = all_users_policies
 
     def update_policies(self):
@@ -32,79 +26,49 @@ class AllUsersService:
             len(self._all_users_policies),
             len(tenants),
         )
+        policies = self.find_policies()
         for tenant_uuid in tenant_uuids:
-            self.update_policies_for_tenant(tenant_uuid)
+            self.associate_policies_for_tenant(tenant_uuid, policies)
 
         commit_or_rollback()
 
-    def update_policies_for_tenant(self, tenant_uuid):
-        all_users_group = self._group_service.get_all_users_group(tenant_uuid)
-        existing_policies = self._policy_service.list(scoping_tenant_uuid=tenant_uuid)
-        existing_policy_slugs = {p['slug']: p['uuid'] for p in existing_policies}
-        associated_policies = self._group_service.list_policies(all_users_group['uuid'])
-        associated_policy_slugs = {p['slug']: p['uuid'] for p in associated_policies}
-        for slug, policy in self._all_users_policies.items():
-            if slug in associated_policy_slugs:
-                associated_policy_uuid = associated_policy_slugs[slug]
-                self._update_policy(
-                    tenant_uuid,
-                    associated_policy_uuid,
-                    slug,
-                    policy,
-                    all_users_group,
-                )
-            elif slug in existing_policy_slugs:
-                existing_policy_uuid = existing_policy_slugs[slug]
-                self._update_policy(
-                    tenant_uuid,
-                    existing_policy_uuid,
-                    slug,
-                    policy,
-                    all_users_group,
-                )
-                self._associate_policy(
-                    tenant_uuid,
-                    existing_policy_uuid,
-                    all_users_group,
-                )
-            else:
-                policy = self._create_policy(tenant_uuid, slug, policy, all_users_group)
-                self._associate_policy(tenant_uuid, policy['uuid'], all_users_group)
+    def find_policies(self):
+        policies = []
+        for slug, enabled in self._all_users_policies.items():
+            if not enabled:
+                logger.debug('all_users: policy disabled: %s', slug)
+                continue
 
-        managed_policies = {**self._default_policies, **self._all_users_policies}
-        policies_to_remove = [
+            policy = self._find_policy(slug)
+            if not policy:
+                logger.error('all_users: Unable to found policy: %s', slug)
+                continue
+            policies.append(policy)
+
+        return policies
+
+    def associate_policies_for_tenant(self, tenant_uuid, policies):
+        all_users_group = self._group_service.get_all_users_group(tenant_uuid)
+        for policy in policies:
+            self._associate_policy(tenant_uuid, policy['uuid'], all_users_group)
+
+        existing_policies = self._policy_service.list(scoping_tenant_uuid=tenant_uuid)
+        policies_to_dissociate = [
             policy
             for policy in existing_policies
-            if policy['config_managed'] and policy['slug'] not in managed_policies
+            if policy['config_managed']
+            and policy['slug'] not in self._all_users_policies
         ]
-        for policy in policies_to_remove:
-            self._group_service.remove_policy(all_users_group['uuid'], policy['uuid'])
-            self._delete_policy(tenant_uuid, policy['uuid'])
+        for policy in policies_to_dissociate:
+            self._dissociate_policy(tenant_uuid, policy['uuid'], all_users_group)
 
-    def _create_policy(self, tenant_uuid, slug, policy, all_users_group):
-        logger.debug('all_users: tenant %s: creating policy %s', tenant_uuid, slug)
-        return self._policy_service.create(
-            name=slug,
+    def _find_policy(self, slug):
+        policies = self._policy_service.list(
             slug=slug,
-            tenant_uuid=tenant_uuid,
-            description='Automatically created to be applied to all users',
-            config_managed=True,
-            **policy,
+            scoping_tenant_uuid=None
         )
-
-    def _update_policy(
-        self, tenant_uuid, policy_uuid, policy_slug, policy, all_users_group
-    ):
-        logger.debug(
-            'all_users: tenant %s: updating policy %s', tenant_uuid, policy_uuid
-        )
-        self._policy_service.update(
-            policy_uuid,
-            name=policy_slug,
-            description='Automatically created to be applied to all users',
-            config_managed=True,
-            **policy,
-        )
+        for policy in policies:
+            return policy
 
     def _associate_policy(self, tenant_uuid, policy_uuid, all_users_group):
         logger.debug(
@@ -115,18 +79,11 @@ class AllUsersService:
         )
         self._group_service.add_policy(all_users_group['uuid'], policy_uuid)
 
-    def _delete_policy(self, tenant_uuid, policy_uuid):
-        if self._policy_service.is_associated(policy_uuid):
-            logger.warning(
-                'all_users: tenant %s: deleting policy %s (SKIPPED: associated)',
-                tenant_uuid,
-                policy_uuid,
-            )
-            return
-
+    def _dissociate_policy(self, tenant_uuid, policy_uuid, all_users_group):
         logger.debug(
-            'all_users: tenant %s: deleting policy %s',
+            'all_users: tenant %s: dissociating policy %s from group %s',
             tenant_uuid,
             policy_uuid,
+            all_users_group['uuid'],
         )
-        self._policy_service.delete(policy_uuid, tenant_uuid)
+        self._group_service.remove_policy(all_users_group['uuid'], policy_uuid)

--- a/wazo_auth/services/group.py
+++ b/wazo_auth/services/group.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_auth import exceptions
@@ -126,3 +126,6 @@ class GroupService(BaseService):
         exists = self._dao.group.exists(uuid, tenant_uuids=tenant_uuids)
         if not exists:
             raise exceptions.UnknownGroupException(uuid)
+
+    def build_tenant_list(self, tenant_uuid):
+        return self._tenant_tree.list_visible_tenants(tenant_uuid)

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -104,8 +104,7 @@ class TenantService(BaseService):
                 continue
 
             all_users_policy = self._policy_service.list(
-                slug=slug,
-                scoping_tenant_uuid=None
+                slug=slug, scoping_tenant_uuid=None
             )[0]
             self._group_service.add_policy(
                 all_users_group['uuid'], all_users_policy['uuid']

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -99,14 +99,14 @@ class TenantService(BaseService):
             name=f'wazo-all-users-tenant-{uuid}', tenant_uuid=uuid, system_managed=True
         )
 
-        for slug, policy in self._all_users_policies.items():
-            all_users_policy = self._policy_service.create(
-                name=slug,
+        for slug, enabled in self._all_users_policies.items():
+            if not enabled:
+                continue
+
+            all_users_policy = self._policy_service.list(
                 slug=slug,
-                tenant_uuid=uuid,
-                description='Automatically created to be applied to all users',
-                **policy,
-            )
+                scoping_tenant_uuid=None
+            )[0]
             self._group_service.add_policy(
                 all_users_group['uuid'], all_users_policy['uuid']
             )


### PR DESCRIPTION
## all_user: move policy creation to default_policies

this also change the all_users_policies config format which is
considered internal

## test: rework all_users tests to include default_policies


## fake the tenant_uuid of default_policies

Since default policies exist only once but are exposed in every tenant,
the tenant_uuid of these policies are fake to the tenant_uuid requested

When recurse is True, then the tenant_uuid remain the original one but
the resource is not seen as duplicated in many tenant. Otherwise it will
result in a duplicate uuid object