### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -41,7 +41,7 @@ from .database import Database
 
 logging.getLogger('wazo_auth').setLevel(logging.WARNING)
 
-HOST = os.getenv('WAZO_AUTH_TEST_HOST', 'localhost')
+HOST = os.getenv('WAZO_AUTH_TEST_HOST', '127.0.0.1')
 SUB_TENANT_UUID = '76502c2b-cce5-409c-ab8f-d1fe41141a2d'
 ADDRESS_NULL = {
     'line_1': None,
@@ -138,7 +138,7 @@ class AuthLaunchingTestCase(AssetLaunchingTestCase):
 
 class BaseTestCase(AuthLaunchingTestCase):
 
-    bus_config = {'user': 'guest', 'password': 'guest', 'host': 'localhost'}
+    bus_config = {'user': 'guest', 'password': 'guest', 'host': '127.0.0.1'}
     email_dir = '/var/mail'
 
     @classmethod

--- a/integration_tests/suite/helpers/constants.py
+++ b/integration_tests/suite/helpers/constants.py
@@ -5,7 +5,7 @@ import os
 
 UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000'
 UNKNOWN_TENANT = '55ee61f3-c4a5-427c-9f40-9d5c33466240'
-DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@localhost:{port}')
+DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@127.0.0.1:{port}')
 ISO_DATETIME = '%Y-%m-%dT%H:%M:%S.%f'
 NB_DEFAULT_GROUPS = 1
 ALL_USERS_POLICY_SLUG = 'wazo-all-users-policy'

--- a/integration_tests/suite/test_auth_microsoft.py
+++ b/integration_tests/suite/test_auth_microsoft.py
@@ -26,7 +26,7 @@ from wazo_auth.database import helpers
 from .helpers.base import BaseTestCase as _BaseTestCase
 
 MICROSOFT = 'microsoft'
-AUTHORIZE_URL = 'http://localhost:{port}/microsoft/authorize/{state}'
+AUTHORIZE_URL = 'http://127.0.0.1:{port}/microsoft/authorize/{state}'
 
 
 class BaseTestCase(_BaseTestCase):
@@ -50,7 +50,7 @@ class BaseTestCase(_BaseTestCase):
 
         port = cls.service_port(9497, 'auth')
         cls.client = Client(
-            'localhost',
+            '127.0.0.1',
             port=port,
             prefix=None,
             https=False,

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -19,6 +19,6 @@ class TestDocumentation(BaseTestCase):
 
     def test_documentation_errors(self):
         port = self.service_port(9497, 'auth')
-        api_url = 'http://localhost:{port}/0.1/api/api.yml'.format(port=port)
+        api_url = 'http://127.0.0.1:{port}/0.1/api/api.yml'.format(port=port)
         api = requests.get(api_url)
         validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/suite/test_external_auth.py
+++ b/integration_tests/suite/test_external_auth.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -213,7 +213,7 @@ class TestExternalAuthAPI(base.WazoAuthTestCase):
 
     def authorize_oauth2(self, auth_type, state, token):
         port = self.service_port(80, 'oauth2sync')
-        url = 'http://localhost:{}/{}/authorize/{}'.format(port, auth_type, state)
+        url = 'http://127.0.0.1:{}/{}/authorize/{}'.format(port, auth_type, state)
         result = requests.get(url, params={'access_token': token})
         result.raise_for_status()
 

--- a/integration_tests/suite/test_google.py
+++ b/integration_tests/suite/test_google.py
@@ -26,7 +26,7 @@ from .helpers.base import BaseTestCase
 
 
 GOOGLE = 'google'
-AUTHORIZE_URL = 'http://localhost:{port}/google/authorize/{state}'
+AUTHORIZE_URL = 'http://127.0.0.1:{port}/google/authorize/{state}'
 
 
 class BaseGoogleTestCase(BaseTestCase):
@@ -49,7 +49,7 @@ class BaseGoogleTestCase(BaseTestCase):
 
         port = cls.service_port(9497, 'auth')
         cls.client = Client(
-            'localhost',
+            '127.0.0.1',
             port=port,
             prefix=None,
             https=False,

--- a/integration_tests/suite/test_ldap_backend.py
+++ b/integration_tests/suite/test_ldap_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import ldap
@@ -73,7 +73,7 @@ class _BaseLDAPTestCase(BaseTestCase):
     def setUpClass(cls):
         super().setUpClass()
         port = cls.service_port(389, 'slapd')
-        ldap_uri = 'ldap://localhost:{port}'.format(port=port)
+        ldap_uri = 'ldap://127.0.0.1:{port}'.format(port=port)
 
         try:
             add_contacts(cls.CONTACTS, ldap_uri)

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -82,7 +82,7 @@ class TestPolicies(WazoAuthTestCase):
             [None],
         ]
 
-        url = 'http://localhost:{}/0.1/policies'.format(self.service_port(9497, 'auth'))
+        url = 'http://127.0.0.1:{}/0.1/policies'.format(self.service_port(9497, 'auth'))
         headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6