### PR TITLE
refactor LocalTokenRenewer to specify custom acl

### DIFF
--- a/wazo_auth/services/token.py
+++ b/wazo_auth/services/token.py
@@ -137,6 +137,27 @@ class TokenService(BaseService):
 
         return token
 
+    def new_token_internal(self, expiration=None, acl=None):
+        expiration = expiration if expiration is not None else self._default_expiration
+        acl = acl or []
+        current_time = time.time()
+        tenant_uuid = self._dao.tenant.find_top_tenant()
+        token_args = {
+            'auth_id': 'wazo-auth',
+            'pbx_user_uuid': None,
+            'xivo_uuid': None,
+            'expire_t': current_time + expiration,
+            'issued_t': current_time,
+            'acl': acl,
+            'metadata': {'tenant_uuid': tenant_uuid},
+            'user_agent': 'wazo-auth-internal',
+            'remote_addr': '127.0.0.1',
+        }
+        session_args = {}
+        token_uuid, session_uuid = self._dao.token.create(token_args, session_args)
+        token = Token(token_uuid, session_uuid=session_uuid, **token_args)
+        return token
+
     def _get_tenant_list(self, tenant_uuid):
         if not tenant_uuid:
             return []

--- a/wazo_auth/tests/test_helpers.py
+++ b/wazo_auth/tests/test_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -11,51 +11,37 @@ from ..helpers import LocalTokenRenewer
 
 class TestLocalTokenRenewer(unittest.TestCase):
     def setUp(self):
-        self._token_service = Mock()
-        self._backend = Mock()
-        self._user_service = Mock()
-        self._user_service.list_users.return_value = [Mock()]
+        self.token_service = Mock()
+        self.acl = ['access.1', 'access.2.#']
 
-        self.local_token_renewer = LocalTokenRenewer(
-            self._backend, self._token_service, self._user_service
-        )
+        self.token_renewer = LocalTokenRenewer(self.token_service, acl=self.acl)
 
     def test_get_token_first_token(self):
-        token = self.local_token_renewer.get_token()
+        token = self.token_renewer.get_token()
 
-        self._token_service.new_token.assert_called_once_with(
-            self._backend.obj,
-            'wazo-auth',
-            {
-                'expiration': 3600,
-                'backend': 'wazo_user',
-                'user_agent': '',
-                'remote_addr': '127.0.0.1',
-            },
+        self.token_service.new_token_internal.assert_called_once_with(
+            expiration=3600,
+            acl=self.acl,
+        )
+        assert_that(
+            token,
+            equal_to(self.token_service.new_token_internal.return_value.token),
         )
 
-        assert_that(token, equal_to(self._token_service.new_token.return_value.token))
-
     def test_that_a_new_token_is_not_created_at_each_call(self):
-        token_1 = self.local_token_renewer.get_token()
-        token_2 = self.local_token_renewer.get_token()
+        token_1 = self.token_renewer.get_token()
+        token_2 = self.token_renewer.get_token()
 
         assert_that(token_1, equal_to(token_2))
 
-    def test_that_a_new_token_does_nothing_when_no_user(self):
-        self._user_service.list_users.return_value = []
-        token = self.local_token_renewer.get_token()
-
-        assert_that(token, equal_to(None))
-
     def test_that_revoke_token_does_nothing_when_no_token(self):
-        self.local_token_renewer.revoke_token()
+        self.token_renewer.revoke_token()
 
-        assert_that(self._token_service.remove_token.called, equal_to(False))
+        assert_that(self.token_service.remove_token.called, equal_to(False))
 
     def test_that_revoke_revokes_the_token(self):
-        token = self.local_token_renewer.get_token()
+        token = self.token_renewer.get_token()
 
-        self.local_token_renewer.revoke_token()
+        self.token_renewer.revoke_token()
 
-        self._token_service.remove_token.assert_called_once_with(token)
+        self.token_service.remove_token.assert_called_once_with(token)


### PR DESCRIPTION
why: only one metadata plugin use it and to avoid to create a specific
user and associate policy to him, we can simply scope the token with
specific ACL