### PR TITLE
policy: fix pagination with limit

### DIFF
--- a/integration_tests/suite/database/test_db_policy.py
+++ b/integration_tests/suite/database/test_db_policy.py
@@ -262,7 +262,9 @@ class TestPolicyDAO(base.DAOTestCase):
     @fixtures.db.user()
     @fixtures.db.policy(name='name1', acl=['1', '2'])
     @fixtures.db.policy(name='name2', acl=['3', '4'])
-    def test_list_group_by_policy(self, user_1, user_2, policy_1, policy_2):
+    def test_list_policy_associated_to_multiple_users_appears_once(
+        self, user_1, user_2, policy_1, policy_2
+    ):
         self._user_dao.add_policy(user_1, policy_1)
         self._user_dao.add_policy(user_2, policy_1)
 

--- a/integration_tests/suite/database/test_db_policy.py
+++ b/integration_tests/suite/database/test_db_policy.py
@@ -259,6 +259,23 @@ class TestPolicyDAO(base.DAOTestCase):
         )
 
     @fixtures.db.user()
+    @fixtures.db.user()
+    @fixtures.db.policy(name='name1', acl=['1', '2'])
+    @fixtures.db.policy(name='name2', acl=['3', '4'])
+    def test_list_group_by_policy(self, user_1, user_2, policy_1, policy_2):
+        self._user_dao.add_policy(user_1, policy_1)
+        self._user_dao.add_policy(user_2, policy_1)
+
+        result = self._policy_dao.list_(search='name', limit=2)
+        assert_that(
+            result,
+            contains_inanyorder(
+                has_properties(uuid=policy_1),
+                has_properties(uuid=policy_2),
+            ),
+        )
+
+    @fixtures.db.user()
     @fixtures.db.policy(name='a')
     @fixtures.db.policy(name='b', description='The second foobar')
     @fixtures.db.policy(name='c', description='The third foobar')

--- a/wazo_auth/database/queries/policy.py
+++ b/wazo_auth/database/queries/policy.py
@@ -157,11 +157,10 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
         query = (
             self.session.query(Policy)
-            .outerjoin(PolicyAccess)
-            .outerjoin(Access)
             .outerjoin(UserPolicy)
             .outerjoin(GroupPolicy)
             .filter(filter_)
+            .group_by(Policy)
         )
         query = self._paginator.update_query(query, **kwargs)
 


### PR DESCRIPTION
why: refactor from 21.07 remove group_by clause. Now this request return
duplicate rows.