### PR TITLE
disallow to delete its own tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 21.10
+
+* Forbid to delete its own tenant
+
 ## 21.09
 
 * Policies endpoints now check that token has enough permission to assign access. To follow this

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,12 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN apt-get -q update
 RUN apt-get -yq install --no-install-recommends gcc libldap2-dev libsasl2-dev
 
-COPY . /usr/src/wazo-auth
+COPY requirements.txt /usr/src/wazo-auth/
 WORKDIR /usr/src/wazo-auth
 RUN pip install -r requirements.txt
+
+COPY setup.py /usr/src/wazo-auth/
+COPY wazo_auth /usr/src/wazo-auth/wazo_auth
 RUN python setup.py install
 
 FROM python:3.7-slim-buster AS build-image

--- a/contribs/docker/Dockerfile-db
+++ b/contribs/docker/Dockerfile-db
@@ -9,7 +9,7 @@ ENV ALEMBIC_DB_URI postgresql://asterisk:proformatique@localhost/asterisk
 RUN true \
     && python3 setup.py install \
     && pg_start \
-    && bin/wazo-auth-init-db --user postgres \
+    && wazo-auth-init-db --user postgres \
     && (cd /usr/src/wazo-auth && alembic -c alembic.ini upgrade head) \
     && pg_stop \
     && true

--- a/debian/wazo-auth.install
+++ b/debian/wazo-auth.install
@@ -1,5 +1,4 @@
 etc/*  etc/
-bin/wazo-auth-init-db usr/bin/
 alembic/ usr/share/wazo-auth/
 alembic.ini usr/share/wazo-auth/
 templates/* var/lib/wazo-auth/templates/

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -225,7 +225,7 @@ class TestTenants(WazoAuthTestCase):
     def test_delete(self, tenant):
         with self.client_in_subtenant() as (client, user, sub_tenant):
             assert_http_error(404, client.tenants.delete, tenant['uuid'])
-            assert_no_error(client.tenants.delete, sub_tenant['uuid'])
+            assert_http_error(403, client.tenants.delete, sub_tenant['uuid'])
 
         assert_no_error(self.client.tenants.delete, tenant['uuid'])
         assert_http_error(404, self.client.tenants.delete, tenant['uuid'])

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from setuptools import find_packages
@@ -18,11 +18,11 @@ setup(
         'wazo_auth.plugins.http': ['*/api.yml'],
         'wazo_auth.plugins.external_auth': ['*/api.yml'],
     },
-    scripts=['bin/wazo-auth-init-db'],
     entry_points={
         'console_scripts': [
             'wazo-auth = wazo_auth.main:main',
             'wazo-auth-bootstrap = wazo_auth.bootstrap:main',
+            'wazo-auth-init-db=wazo_auth.init_db:main',
             'wazo-auth-wait=wazo_auth.wait:main',
         ],
         'wazo_auth.backends': [

--- a/wazo_auth/init_db.py
+++ b/wazo_auth/init_db.py
@@ -14,18 +14,41 @@ from xivo.xivo_logging import setup_logging
 
 def _parse_cli_args(args):
     parser = argparse.ArgumentParser()
-    parser.add_argument('--user', action='store',
-                        help="The system user to use to connect to postgresql and create the user and database")
-    parser.add_argument('--pg_db_uri', action='store', default='postgresql:///postgres',
-                        help="The DSN to connect to the postgres DB as an superuser")
-    parser.add_argument('--auth_db_uri', action='store', default='postgresql:///asterisk',
-                        help="The DSN to connect to the auth DB as an superuser")
-    parser.add_argument('--db', action='store', default='asterisk',
-                        help="The database name that will be created")
-    parser.add_argument('--owner', action='store', default='asterisk',
-                        help="The database user that will be created and that will own the database")
-    parser.add_argument('--password', action='store', default='proformatique',
-                        help="The password that will be assigned to the created user")
+    parser.add_argument(
+        '--user',
+        action='store',
+        help="The system user to use to connect to postgresql and create the user and database",
+    )
+    parser.add_argument(
+        '--pg_db_uri',
+        action='store',
+        default='postgresql:///postgres',
+        help="The DSN to connect to the postgres DB as an superuser",
+    )
+    parser.add_argument(
+        '--auth_db_uri',
+        action='store',
+        default='postgresql:///asterisk',
+        help="The DSN to connect to the auth DB as an superuser",
+    )
+    parser.add_argument(
+        '--db',
+        action='store',
+        default='asterisk',
+        help="The database name that will be created",
+    )
+    parser.add_argument(
+        '--owner',
+        action='store',
+        default='asterisk',
+        help="The database user that will be created and that will own the database",
+    )
+    parser.add_argument(
+        '--password',
+        action='store',
+        default='proformatique',
+        help="The password that will be assigned to the created user",
+    )
     return parser.parse_args(args)
 
 

--- a/wazo_auth/init_db.py
+++ b/wazo_auth/init_db.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -59,7 +58,3 @@ def main():
     with conn:
         with conn.cursor() as cursor:
             db_helper.create_db_extensions(cursor, ['uuid-ossp'])
-
-
-if __name__ == '__main__':
-    main()

--- a/wazo_auth/plugins/http/tenants/exceptions.py
+++ b/wazo_auth/plugins/http/tenants/exceptions.py
@@ -1,0 +1,12 @@
+# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from xivo.rest_api_helpers import APIException
+
+
+class DeleteOwnTenantForbidden(APIException):
+    def __init__(self, tenant_uuid):
+        details = {'tenant_uuid': tenant_uuid}
+        msg = f'Deleting its own tenant is forbidden: "{tenant_uuid}"'
+        error_id = 'deleting-own-tenant-forbidden'
+        super().__init__(403, msg, error_id, details, resource='tenants')

--- a/wazo_auth/plugins/http/tenants/http.py
+++ b/wazo_auth/plugins/http/tenants/http.py
@@ -4,10 +4,12 @@
 import logging
 
 from flask import request
+from marshmallow import ValidationError
+
 from wazo_auth import exceptions, http, schemas
 from wazo_auth.flask_helpers import Tenant as TenantDetector
 
-from marshmallow import ValidationError
+from .exceptions import DeleteOwnTenantForbidden
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +25,8 @@ class Tenant(BaseResource):
         scoping_tenant = TenantDetector.autodetect()
 
         logger.debug('deleting tenant %s from %s', tenant_uuid, scoping_tenant.uuid)
+        if scoping_tenant.uuid == tenant_uuid:
+            raise DeleteOwnTenantForbidden(tenant_uuid)
 
         self.tenant_service.delete(scoping_tenant.uuid, tenant_uuid)
 


### PR DESCRIPTION
why: avoid mistake and too much privilege. To make such action, a
dedicate endpoint should be done because the use case is totally
different than deleting a sub-tenant