### PR TITLE
policies: allow adding negative ACL

### DIFF
--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -154,7 +154,7 @@ class TestPolicies(base.APIIntegrationTest):
 
         policy_args = {
             'name': 'authorized',
-            'acl': ['authorized'],
+            'acl': ['authorized', '!forbid-access'],
         }
         policy = user_client.policies.new(**policy_args)
         assert_that(policy, has_entries(**policy_args))
@@ -366,7 +366,7 @@ class TestPolicies(base.APIIntegrationTest):
         new_body['acl'] = ['authorized', 'unauthorized']
         assert_http_error(401, user_client.policies.edit, policy['uuid'], **new_body)
 
-        new_body['acl'] = ['authorized']
+        new_body['acl'] = ['authorized', '!forbid-access']
         user_client.policies.edit(policy['uuid'], **new_body)
 
         policy = user_client.policies.get(policy['uuid'])
@@ -417,9 +417,10 @@ class TestPolicies(base.APIIntegrationTest):
         )
 
         user_client.policies.add_access(policy['uuid'], 'authorized')
+        user_client.policies.add_access(policy['uuid'], '!forbid-access')
 
         policy = user_client.policies.get(policy['uuid'])
-        assert_that(policy, has_entries(acl=['authorized']))
+        assert_that(policy, has_entries(acl=['authorized', '!forbid-access']))
 
         self.client.policies.delete(user_policy['uuid'])
 

--- a/integration_tests/suite/test_user_policy.py
+++ b/integration_tests/suite/test_user_policy.py
@@ -74,7 +74,7 @@ class TestUsers(base.APIIntegrationTest):
 
     @fixtures.http.user(username='foo', password='bar')
     @fixtures.http.user()
-    @fixtures.http.policy(acl=['authorized'])
+    @fixtures.http.policy(acl=['authorized', '!forbid-access'])
     @fixtures.http.policy(acl=['authorized', 'unauthorized'])
     def test_put_when_policy_has_more_access_than_token(
         self, login, user, policy1, policy2

--- a/wazo_auth/plugins/http/policies/http.py
+++ b/wazo_auth/plugins/http/policies/http.py
@@ -29,7 +29,7 @@ class Policies(_BasePolicyRessource):
 
         access_check = AccessCheck(token.auth_id, token.session_uuid, token.acl)
         for access in body['acl']:
-            if not access_check.matches_required_access(access):
+            if not access_check.may_add_access(access):
                 raise Unauthorized(token.token, required_access=access)
 
         policy = self.policy_service.create(**body)
@@ -70,7 +70,7 @@ class _Policy(_BasePolicyRessource):
 
         access_check = AccessCheck(token.auth_id, token.session_uuid, token.acl)
         for access in body['acl']:
-            if not access_check.matches_required_access(access):
+            if not access_check.may_add_access(access):
                 raise Unauthorized(token.token, required_access=access)
 
         body['tenant_uuids'] = tenant_uuids
@@ -123,7 +123,7 @@ class _PolicyAccess(_BasePolicyRessource):
     def _put(self, policy_uuid, access, tenant_uuids):
         token = Token.from_headers()
         access_check = AccessCheck(token.auth_id, token.session_uuid, token.acl)
-        if not access_check.matches_required_access(access):
+        if not access_check.may_add_access(access):
             raise Unauthorized(token.token, required_access=access)
 
         self.policy_service.add_access(policy_uuid, access, tenant_uuids)

--- a/wazo_auth/plugins/http/user_policy/http.py
+++ b/wazo_auth/plugins/http/user_policy/http.py
@@ -61,7 +61,7 @@ class _UserPolicy(_BaseUserPolicyResource):
         # policy = self.policy_service.get(policy_uuid, tenant_uuids)
         policy = self.policy_service.get(policy_uuid, tenant_uuids=None)
         for access in policy.acl:
-            if not access_check.matches_required_access(access):
+            if not access_check.may_add_access(access):
                 raise Unauthorized(token.token, required_access=access)
 
         self.user_service.add_policy(user_uuid, policy_uuid)


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/85

Why:

* Admins may want to restrict permissions of some users