### PR TITLE
policies: restrict negative access removal

### DIFF
--- a/integration_tests/suite/helpers/fixtures/http.py
+++ b/integration_tests/suite/helpers/fixtures/http.py
@@ -215,6 +215,7 @@ def policy(**policy_args):
                     result = decorated(self, *args, **kwargs)
             finally:
                 try:
+                    self.client.set_token(self.admin_token)
                     self.client.policies.delete(policy['uuid'])
                 except requests.HTTPError:
                     pass

--- a/integration_tests/suite/test_group_policy.py
+++ b/integration_tests/suite/test_group_policy.py
@@ -144,12 +144,11 @@ class TestGroupPolicyAssociation(base.APIIntegrationTest):
     @fixtures.http.group()
     @fixtures.http.policy(acl=['authorized', '!forbid-access'])
     @fixtures.http.policy(acl=['authorized', 'unauthorized'])
+    @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
     def test_put_when_policy_has_more_access_than_token(
-        self, login, group, policy1, policy2
+        self, login, group, policy1, policy2, user_policy
     ):
         user_client = self.make_auth_client('foo', 'bar')
-        acl = ['auth.#', 'authorized', '!unauthorized']
-        user_policy = self.client.policies.new(name='foo-policy', acl=acl)
         self.client.users.add_policy(login['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -168,8 +167,6 @@ class TestGroupPolicyAssociation(base.APIIntegrationTest):
 
         result = self.client.groups.get_policies(group['uuid'])
         assert_that(result, has_entries(items=contains_exactly(policy1)))
-
-        self.client.policies.delete(user_policy['uuid'])
 
     @fixtures.http.group()
     @fixtures.http.policy(name='foo')

--- a/integration_tests/suite/test_group_policy.py
+++ b/integration_tests/suite/test_group_policy.py
@@ -44,7 +44,9 @@ class TestGroupPolicyAssociation(base.APIIntegrationTest):
             # Any policies of a visible group can be removed.
             client.groups.add_policy(visible_group['uuid'], visible_policy['uuid'])
             base.assert_no_error(
-                client.groups.remove_policy, visible_group['uuid'], visible_policy['uuid']
+                client.groups.remove_policy,
+                visible_group['uuid'],
+                visible_policy['uuid'],
             )
 
         base.assert_http_error(

--- a/integration_tests/suite/test_group_policy.py
+++ b/integration_tests/suite/test_group_policy.py
@@ -42,9 +42,9 @@ class TestGroupPolicyAssociation(base.APIIntegrationTest):
             )
 
             # Any policies of a visible group can be removed.
-            self.client.groups.add_policy(visible_group['uuid'], policy1['uuid'])
+            client.groups.add_policy(visible_group['uuid'], visible_policy['uuid'])
             base.assert_no_error(
-                client.groups.remove_policy, visible_group['uuid'], policy1['uuid']
+                client.groups.remove_policy, visible_group['uuid'], visible_policy['uuid']
             )
 
         base.assert_http_error(

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -512,7 +512,7 @@ class TestPolicies(base.APIIntegrationTest):
 
         # Removing authorized access
         new_body = dict(policy_restrictive)
-        new_body['acl'] = ['!unauthorized']  # removed authorized and !anything
+        new_body['acl'] = ['!unauthorized', '!anything']  # removed authorized
         user_client.policies.edit(policy_restrictive['uuid'], **new_body)
 
         policy = user_client.policies.get(policy_restrictive['uuid'])

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -521,8 +521,6 @@ class TestPolicies(base.APIIntegrationTest):
         policy = user_client.policies.get(policy_restrictive['uuid'])
         assert_that(policy, has_entries(acl=new_body['acl']))
 
-        self.client.policies.delete(user_policy['uuid'])
-
     @fixtures.http.policy(acl=['dird.me.#', 'ctid-ng.#'])
     def test_add_access(self, policy):
         assert_http_error(404, self.client.policies.add_access, UNKNOWN_UUID, '#')
@@ -573,8 +571,6 @@ class TestPolicies(base.APIIntegrationTest):
         policy = user_client.policies.get(policy['uuid'])
         assert_that(policy, has_entries(acl=['authorized', '!forbid-access']))
 
-        self.client.policies.delete(user_policy['uuid'])
-
     @fixtures.http.policy(acl=['dird.me.#', 'ctid-ng.#'])
     def test_remove_access(self, policy):
         assert_http_error(404, self.client.policies.remove_access, UNKNOWN_UUID, '#')
@@ -615,8 +611,6 @@ class TestPolicies(base.APIIntegrationTest):
 
         policy = user_client.policies.get(policy['uuid'])
         assert_that(policy, has_entries(acl=['!unauthorized']))
-
-        self.client.policies.delete(user_policy['uuid'])
 
 
 @base.use_asset('base')

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -181,10 +181,9 @@ class TestPolicies(base.APIIntegrationTest):
             assert_that(policy, has_entries(slug='first'))
 
     @fixtures.http.user(username='foo', password='bar')
-    def test_post_when_policy_has_more_access_than_token(self, user):
+    @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
+    def test_post_when_policy_has_more_access_than_token(self, user, user_policy):
         user_client = self.make_auth_client('foo', 'bar')
-        acl = ['auth.#', 'authorized', '!unauthorized']
-        user_policy = self.client.policies.new(name='foo-policy', acl=acl)
         self.client.users.add_policy(user['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -203,7 +202,6 @@ class TestPolicies(base.APIIntegrationTest):
         assert_that(policy, has_entries(**policy_args))
 
         self.client.policies.delete(policy['uuid'])
-        self.client.policies.delete(user_policy['uuid'])
 
     @fixtures.http.tenant(uuid=SUB_TENANT_UUID)
     @fixtures.http.policy(name='one', tenant_uuid=SUB_TENANT_UUID)
@@ -483,12 +481,11 @@ class TestPolicies(base.APIIntegrationTest):
     @fixtures.http.user(username='foo', password='bar')
     @fixtures.http.policy()
     @fixtures.http.policy(acl=['authorized', '!anything', '!unauthorized'])
+    @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
     def test_put_when_policy_has_more_access_than_token(
-        self, user, policy_empty, policy_restrictive
+        self, user, policy_empty, policy_restrictive, user_policy
     ):
         user_client = self.make_auth_client('foo', 'bar')
-        acl = ['auth.#', 'authorized', '!unauthorized']
-        user_policy = self.client.policies.new(name='foo-policy', acl=acl)
         self.client.users.add_policy(user['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -549,11 +546,12 @@ class TestPolicies(base.APIIntegrationTest):
         )
 
     @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
     @fixtures.http.policy()
-    def test_add_access_when_policy_has_more_access_than_token(self, user, policy):
+    def test_add_access_when_policy_has_more_access_than_token(
+        self, user, user_policy, policy
+    ):
         user_client = self.make_auth_client('foo', 'bar')
-        acl = ['auth.#', 'authorized', '!unauthorized']
-        user_policy = self.client.policies.new(name='foo-policy', acl=acl)
         self.client.users.add_policy(user['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -592,10 +590,11 @@ class TestPolicies(base.APIIntegrationTest):
 
     @fixtures.http.user(username='foo', password='bar')
     @fixtures.http.policy(acl=['authorized', '!unauthorized'])
-    def test_remove_access_when_negative_access_in_token(self, user, policy):
+    @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
+    def test_remove_access_when_negative_access_in_token(
+        self, user, policy, user_policy
+    ):
         user_client = self.make_auth_client('foo', 'bar')
-        acl = ['auth.#', 'authorized', '!unauthorized']
-        user_policy = self.client.policies.new(name='foo-policy', acl=acl)
         self.client.users.add_policy(user['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)

--- a/integration_tests/suite/test_user_policy.py
+++ b/integration_tests/suite/test_user_policy.py
@@ -80,12 +80,11 @@ class TestUsers(base.APIIntegrationTest):
     @fixtures.http.user()
     @fixtures.http.policy(acl=['authorized', '!forbid-access'])
     @fixtures.http.policy(acl=['authorized', 'unauthorized'])
+    @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
     def test_put_when_policy_has_more_access_than_token(
-        self, login, user, policy1, policy2
+        self, login, user, policy1, policy2, user_policy
     ):
         user_client = self.make_auth_client('foo', 'bar')
-        acl = ['auth.#', 'authorized', '!unauthorized']
-        user_policy = self.client.policies.new(name='foo-policy', acl=acl)
         self.client.users.add_policy(login['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -104,8 +103,6 @@ class TestUsers(base.APIIntegrationTest):
 
         result = self.client.users.get_policies(user['uuid'])
         assert_that(result, has_entries(items=contains_exactly(policy1)))
-
-        self.client.policies.delete(user_policy['uuid'])
 
     @fixtures.http.tenant(uuid=SUB_TENANT_UUID)
     @fixtures.http.user(tenant_uuid=SUB_TENANT_UUID)
@@ -198,15 +195,14 @@ class TestUserPolicySlug(base.APIIntegrationTest):
     @fixtures.http.user()
     @fixtures.http.policy(acl=['authorized'])
     @fixtures.http.policy(acl=['authorized', '!unauthorized'])
+    @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
     def test_delete_when_policy_negative_access_in_token(
-        self, login, user, policy1, policy2
+        self, login, user, policy1, policy2, user_policy
     ):
         self.client.users.add_policy(user['uuid'], policy1['uuid'])
         self.client.users.add_policy(user['uuid'], policy2['uuid'])
 
         user_client = self.make_auth_client('foo', 'bar')
-        acl = ['auth.#', 'authorized', '!unauthorized']
-        user_policy = self.client.policies.new(name='foo-policy', acl=acl)
         self.client.users.add_policy(login['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -225,8 +221,6 @@ class TestUserPolicySlug(base.APIIntegrationTest):
 
         result = self.client.users.get_policies(user['uuid'])
         assert_that(result, has_entries(items=contains(policy2)))
-
-        self.client.policies.delete(user_policy['uuid'])
 
     @fixtures.http.user()
     @fixtures.http.policy()

--- a/wazo_auth/plugins/http/group_policy/http.py
+++ b/wazo_auth/plugins/http/group_policy/http.py
@@ -26,6 +26,14 @@ class _GroupPolicy(_BaseResource):
         self.group_service.assert_group_in_subtenant(tenant_uuids, group_uuid)
         # FIXME(fblackburn): Dissociation should be done on the same tenant
         # self.policy_service.assert_policy_in_subtenant(tenant_uuids, policy_uuid)
+
+        token = Token.from_headers()
+        access_check = AccessCheck(token.auth_id, token.session_uuid, token.acl)
+        policy = self.policy_service.get(policy_uuid, tenant_uuids)
+        for access in policy.acl:
+            if not access_check.may_remove_access(access):
+                raise Unauthorized(token.token, required_access=access)
+
         self.group_service.remove_policy(group_uuid, policy_uuid)
         return '', 204
 

--- a/wazo_auth/plugins/http/user_policy/http.py
+++ b/wazo_auth/plugins/http/user_policy/http.py
@@ -45,6 +45,12 @@ class _UserPolicy(_BaseUserPolicyResource):
         # self.policy_service.assert_user_in_subtenant(tenant_uuids, policy_uuid)
         # FIXME(fblackburn): Dissociation should be done on the same tenant
         # self.policy_service.assert_policy_in_subtenant(tenant_uuids, policy_uuid)
+        token = Token.from_headers()
+        policy = self.policy_service.get(policy_uuid, tenant_uuids)
+        access_check = AccessCheck(token.auth_id, token.session_uuid, token.acl)
+        for access in policy.acl:
+            if not access_check.may_remove_access(access):
+                raise Unauthorized(token.token, required_access=access)
         self.user_service.remove_policy(user_uuid, policy_uuid)
         return '', 204
 


### PR DESCRIPTION
Why:

* A user could escalate privileges by removing the negative accesses
applying to itself

Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/154