### PR TITLE
do not use deprecated python client method

### DIFF
--- a/integration_tests/suite/test_mobile.py
+++ b/integration_tests/suite/test_mobile.py
@@ -38,7 +38,7 @@ class TestExternalAuthMobile(base.ExternalAuthIntegrationTest):
     @fixtures.http.user(username='one', password='pass', tenant_uuid=TENANT_UUID)
     @fixtures.http.token(username='one', password='pass', expiration=30)
     def test_mobile_workflow(self, tenant, user, token):
-        self.client.set_tenant(tenant['uuid'])
+        self.client.tenant_uuid = tenant['uuid']
         self.client.external.create_config(
             auth_type=self.EXTERNAL_AUTH_TYPE, data=self.SECRET
         )

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -149,9 +149,9 @@ class TestTenants(base.APIIntegrationTest):
         # Assert default policies from tenant point of view
         result = []
         for group in wazo_all_users_groups:
-            self.client.set_tenant(group['tenant_uuid'])
+            self.client.tenant_uuid = group['tenant_uuid']
             policies = self.client.groups.get_policies(group['uuid'])['items']
-            self.client.set_tenant(None)
+            self.client.tenant_uuid = None
             result.append({'group': group, 'policies': policies})
 
         assert_that(


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-lib-rest-client/pull/10