### PR TITLE
Wazo-658: Change 500 error message when deleting tenant with children to a user-freindly message

### DIFF
--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -229,6 +229,15 @@ class TestTenants(base.APIIntegrationTest):
         assert_no_error(self.client.tenants.delete, tenant['uuid'])
         assert_http_error(404, self.client.tenants.delete, tenant['uuid'])
 
+    @fixtures.http.tenant()
+    def test_delete_tenant_with_children(self, tenant):
+        with self.client_in_subtenant(parent_uuid=tenant['uuid']) as (
+            client,
+            user,
+            sub_tenant,
+        ):
+            assert_http_error(400, self.client.tenants.delete, tenant['uuid'])
+
     @fixtures.http.tenant(address=ADDRESS_1)
     def test_get_one(self, tenant):
         with self.client_in_subtenant() as (client, user, sub_tenant):

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -104,7 +104,19 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         tenant = self.session.query(Tenant).get(uuid)
         if not tenant:
             raise exceptions.UnknownTenantException(uuid)
-        self.session.delete(tenant)
+
+        children_count = (
+            self.session.query(Tenant).filter(Tenant.parent_uuid == uuid).count()
+        )
+
+        if children_count > 0:
+
+            raise exceptions.UnauthorizedTenantwithChildrenDelete(uuid)
+
+        else:
+
+            self.session.delete(tenant)
+
         self.session.flush()
         # NOTE: A lot of resources have been delete by cascade
         self.session.expire_all()

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -130,6 +130,15 @@ class UnknownTenantException(APIException):
         super().__init__(404, msg, 'unknown-tenant', details, 'tenants')
 
 
+class UnauthorizedTenantwithChildrenDelete(APIException):
+    def __init__(self, tenant_uuid):
+        msg = 'Unauthorized delete of tenant : "{}" ; since it has at least one child'.format(
+            tenant_uuid
+        )
+        details = {'uuid': str(tenant_uuid)}
+        super().__init__(400, msg, details, 'tenants')
+
+
 class UnknownEmailException(APIException):
     def __init__(self, email_uuid):
         msg = 'No such email: "{}"'.format(email_uuid)


### PR DESCRIPTION
Some integration tests failed on my machine, but I think that the issue in the ticket (WAZO-658) is fixed.