### PR TITLE
nginx: avoid an error when reloading nginx

### DIFF
--- a/etc/nginx/locations/https-available/wazo-auth
+++ b/etc/nginx/locations/https-available/wazo-auth
@@ -1,11 +1,11 @@
 location ^~ /api/auth/0.1/backends {
     include /etc/nginx/wazo-auth-shared.conf;
-    include /etc/nginx/wazo-no-auth-shared.conf;
+    include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
 location ^~ /api/auth/0.1/status {
     include /etc/nginx/wazo-auth-shared.conf;
-    include /etc/nginx/wazo-no-auth-shared.conf;
+    include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
 location ^~ /api/auth/ {

--- a/etc/nginx/locations/https-available/wazo-auth
+++ b/etc/nginx/locations/https-available/wazo-auth
@@ -1,13 +1,16 @@
 location ^~ /api/auth/0.1/backends {
+    proxy_pass http://127.0.0.1:9497/0.1/backends;
     include /etc/nginx/wazo-auth-shared.conf;
     include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
 location ^~ /api/auth/0.1/status {
+    proxy_pass http://127.0.0.1:9497/0.1/status;
     include /etc/nginx/wazo-auth-shared.conf;
     include /etc/nginx/wazo-no-auth-shared[.]conf;
 }
 
 location ^~ /api/auth/ {
+    proxy_pass http://127.0.0.1:9497/;
     include /etc/nginx/wazo-auth-shared.conf;
 }

--- a/etc/nginx/wazo-auth-shared.conf
+++ b/etc/nginx/wazo-auth-shared.conf
@@ -1,5 +1,3 @@
-proxy_pass http://127.0.0.1:9497/;
-
 proxy_set_header    Host                $http_host;
 proxy_set_header    X-Script-Name       /api/auth;
 proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;


### PR DESCRIPTION
when wazo-auth gets installed before wazo-nginx the wazo-no-auth-shared.conf
file will not exist. adding a wildcard will avoid the error but will not allow
anyother file to be matched