### PR TITLE
Wazo-2638: Migration of Wazo Auth from Marshmallow 3.0.0b14 to 3.10.0.

### DIFF
--- a/integration_tests/assets/external_auth/service_plugin/src/plugin.py
+++ b/integration_tests/assets/external_auth/service_plugin/src/plugin.py
@@ -90,7 +90,7 @@ class BarSafeData(Schema):
     scope = fields.List(fields.String)
 
     @pre_load
-    def ensure_dict(self, data):
+    def ensure_dict(self, data, **kwargs):
         return data or {}
 
 

--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -17,5 +17,5 @@ jinja2==2.10
 psycopg2-binary
 stevedore==1.29.0
 unidecode==1.0.23
-marshmallow==3.0.0b14
+marshmallow==3.10.0
 python-consul==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ jinja2==2.10
 jsonpatch==1.21
 kombu==4.6.11
 markupsafe==1.1.0  # from flask
-marshmallow==3.0.0b14
+marshmallow==3.10.0
 netifaces==0.10.4
 psycopg2==2.7.7
 python-consul==0.7.1

--- a/wazo_auth/plugins/http/password_reset/schemas.py
+++ b/wazo_auth/plugins/http/password_reset/schemas.py
@@ -19,7 +19,7 @@ class PasswordResetQueryParameters(BaseSchema):
     email_address = fields.Email(data_key='email', missing=None)
 
     @validates_schema
-    def validate_mutually_exclusive_fields(self, data):
+    def validate_mutually_exclusive_fields(self, data, **kwargs):
         username = data.get('username')
         email = data.get('email_address')
 

--- a/wazo_auth/plugins/http/policies/schemas.py
+++ b/wazo_auth/plugins/http/policies/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import post_dump
@@ -23,7 +23,7 @@ class PolicyFullSchema(BaseSchema):
     shared = fields.Boolean(missing=False)
 
     @post_dump(pass_original=True)
-    def set_shared_exposed_only_for_dump(self, data, original):
+    def set_shared_exposed_only_for_dump(self, data, original, **kwargs):
         data['shared'] = original.shared_exposed
         return data
 

--- a/wazo_auth/plugins/http/tokens/schemas.py
+++ b/wazo_auth/plugins/http/tokens/schemas.py
@@ -19,7 +19,7 @@ class TokenRequestSchema(BaseSchema):
     tenant_id = fields.String()
 
     @validates_schema
-    def check_access_type_usage(self, data):
+    def check_access_type_usage(self, data, **kwargs):
         access_type = data.get('access_type')
         if access_type != 'offline':
             return
@@ -37,7 +37,7 @@ class TokenRequestSchema(BaseSchema):
             )
 
     @validates_schema
-    def check_backend_type_for_tenant(self, data):
+    def check_backend_type_for_tenant(self, data, **kwargs):
         backend = data.get('backend')
         if not backend == 'ldap_user':
             return
@@ -49,7 +49,7 @@ class TokenRequestSchema(BaseSchema):
             )
 
     @validates_schema
-    def check_refresh_token_usage(self, data):
+    def check_refresh_token_usage(self, data, **kwargs):
         refresh_token = data.get('refresh_token')
         if not refresh_token:
             return

--- a/wazo_auth/plugins/http/tokens/tests/test_schemas.py
+++ b/wazo_auth/plugins/http/tokens/tests/test_schemas.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from marshmallow.exceptions import ValidationError
 
-from hamcrest import assert_that, calling, has_properties, has_item, not_
+from hamcrest import assert_that, calling, has_properties, not_
 from wazo_test_helpers.hamcrest.raises import raises
 
 from ..schemas import TokenRequestSchema
@@ -22,9 +22,7 @@ class TestTokenRequestSchema(TestCase):
             body = {'expiration': value}
             assert_that(
                 calling(self.schema.load).with_args(body),
-                raises(ValidationError).matching(
-                    has_properties(field_names=has_item('expiration'))
-                ),
+                raises(ValidationError).matching(has_properties(field_name='expiration')),
             )
 
     def test_minimal_body(self):
@@ -36,9 +34,7 @@ class TestTokenRequestSchema(TestCase):
 
         assert_that(
             calling(self.schema.load).with_args(body),
-            raises(ValidationError).matching(
-                has_properties(field_names=has_item('_schema'))
-            ),
+            raises(ValidationError).matching(has_properties(field_name='_schema')),
         )
 
     def test_that_the_access_type_is_online_when_using_a_refresh_token(self):
@@ -53,9 +49,7 @@ class TestTokenRequestSchema(TestCase):
 
         assert_that(
             calling(self.schema.load).with_args({'access_type': 'offline', **body}),
-            raises(ValidationError).matching(
-                has_properties(field_names=has_item('_schema'))
-            ),
+            raises(ValidationError).matching(has_properties(field_name='_schema')),
         )
 
     def test_that_a_refresh_token_requires_a_client_id(self):
@@ -68,9 +62,7 @@ class TestTokenRequestSchema(TestCase):
 
         assert_that(
             calling(self.schema.load).with_args(body),
-            raises(ValidationError).matching(
-                has_properties(field_names=has_item('_schema'))
-            ),
+            raises(ValidationError).matching(has_properties(field_name='_schema')),
         )
 
     def test_that_ldap_backend_requires_tenant_id(self):

--- a/wazo_auth/plugins/http/tokens/tests/test_schemas.py
+++ b/wazo_auth/plugins/http/tokens/tests/test_schemas.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from marshmallow.exceptions import ValidationError
 
-from hamcrest import assert_that, calling, has_properties, not_
+from hamcrest import assert_that, calling, has_properties, has_key, not_
 from wazo_test_helpers.hamcrest.raises import raises
 
 from ..schemas import TokenRequestSchema
@@ -22,7 +22,9 @@ class TestTokenRequestSchema(TestCase):
             body = {'expiration': value}
             assert_that(
                 calling(self.schema.load).with_args(body),
-                raises(ValidationError).matching(has_properties(field_name='expiration')),
+                raises(ValidationError).matching(
+                    has_properties(messages=has_key('expiration'))
+                ),
             )
 
     def test_minimal_body(self):

--- a/wazo_auth/plugins/http/tokens/tests/test_schemas.py
+++ b/wazo_auth/plugins/http/tokens/tests/test_schemas.py
@@ -77,7 +77,5 @@ class TestTokenRequestSchema(TestCase):
 
         assert_that(
             calling(self.schema.load).with_args(body),
-            raises(ValidationError).matching(
-                has_properties(field_names=has_item('_schema'))
-            ),
+            raises(ValidationError).matching(has_properties(field_name='_schema')),
         )

--- a/wazo_auth/plugins/http/user_email/schemas.py
+++ b/wazo_auth/plugins/http/user_email/schemas.py
@@ -1,7 +1,7 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from marshmallow import EXCLUDE, post_load, validates_schema, ValidationError
+from marshmallow import post_load, validates_schema, ValidationError
 from xivo.mallow import fields
 from wazo_auth.schemas import BaseSchema
 
@@ -50,8 +50,8 @@ class _EmailPutSchema(BaseSchema):
 
 
 class AdminEmailPutSchema(_EmailPutSchema):
-    emails = fields.Nested(_AdminEmailSchema, required=True, many=True, unknown=EXCLUDE)
+    emails = fields.Nested(_AdminEmailSchema, required=True, many=True)
 
 
 class UserEmailPutSchema(_EmailPutSchema):
-    emails = fields.Nested(_UserEmailSchema, required=True, many=True, unknown=EXCLUDE)
+    emails = fields.Nested(_UserEmailSchema, required=True, many=True)

--- a/wazo_auth/plugins/http/user_email/schemas.py
+++ b/wazo_auth/plugins/http/user_email/schemas.py
@@ -21,11 +21,11 @@ class _UserEmailSchema(BaseSchema):
 
 class _EmailPutSchema(BaseSchema):
     @post_load
-    def as_list(self, data):
+    def as_list(self, data, **kwargs):
         return data['emails']
 
     @validates_schema
-    def validate_only_one_main(self, data):
+    def validate_only_one_main(self, data, **kwargs):
         emails = data.get('emails')
         if not emails:
             return
@@ -39,7 +39,7 @@ class _EmailPutSchema(BaseSchema):
             raise ValidationError('At least one address should be main')
 
     @validates_schema
-    def validate_no_duplicates(self, data):
+    def validate_no_duplicates(self, data, **kwargs):
         emails = data.get('emails')
         if not emails:
             return

--- a/wazo_auth/schemas.py
+++ b/wazo_auth/schemas.py
@@ -61,7 +61,7 @@ class TenantFullSchema(BaseSchema):
     )
 
     @post_dump
-    def add_empty_address(self, data):
+    def add_empty_address(self, data, **kwargs):
         data['address'] = data['address'] or empty_tenant_address
         return data
 


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/93