### PR TITLE
WP-494: active directory compatiblity

### DIFF
--- a/integration_tests/assets/docker-compose.ldap.override.yml
+++ b/integration_tests/assets/docker-compose.ldap.override.yml
@@ -8,10 +8,6 @@ services:
     environment:
       TARGETS: "slapd:389 postgres:5432 auth:9497"
 
-  postgres:
-    volumes:
-      - "./postgres_data/populate.ldap.sql:/pg-init-db/populate.sql"
-
   auth:
     volumes:
       - "./etc/wazo-auth/conf.d/asset.ldap.yml:/etc/wazo-auth/conf.d/asset.ldap.yml"

--- a/integration_tests/assets/docker-compose.ldap_anonymous.override.yml
+++ b/integration_tests/assets/docker-compose.ldap_anonymous.override.yml
@@ -8,10 +8,6 @@ services:
     environment:
       TARGETS: "slapd:389 postgres:5432 auth:9497"
 
-  postgres:
-    volumes:
-      - "./postgres_data/populate.ldap.hardcoded.sql:/pg-init-db/populate.sql"
-
   auth:
     volumes:
       - "./etc/wazo-auth/conf.d/asset.ldap_anonymous.yml:/etc/wazo-auth/conf.d/asset.ldap_anonymous.yml"

--- a/integration_tests/assets/docker-compose.ldap_service_user.override.yml
+++ b/integration_tests/assets/docker-compose.ldap_service_user.override.yml
@@ -8,10 +8,6 @@ services:
     environment:
       TARGETS: "slapd:389 postgres:5432 auth:9497"
 
-  postgres:
-    volumes:
-      - "./postgres_data/populate.ldap.hardcoded.sql:/pg-init-db/populate.sql"
-
   auth:
     volumes:
       - "./etc/wazo-auth/conf.d/asset.ldap_service_user.yml:/etc/wazo-auth/conf.d/asset.ldap_service_user.yml"

--- a/integration_tests/assets/etc/wazo-auth/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/50-default.yml
@@ -4,7 +4,6 @@ rest_api:
   listen: 0.0.0.0
 
 db_uri: postgresql://asterisk:proformatique@postgres:5432
-confd_db_uri: postgresql://asterisk:proformatique@postgres:5432
 amqp:
   uri: amqp://guest:guest@rabbitmq:5672/
 

--- a/integration_tests/assets/postgres_data/populate.ldap.hardcoded.sql
+++ b/integration_tests/assets/postgres_data/populate.ldap.hardcoded.sql
@@ -1,5 +1,0 @@
-INSERT INTO "tenant" (uuid) VALUES ('4a037de3-94bd-4d40-b4d1-3fc09184c3d2') ON CONFLICT DO NOTHING;
-INSERT INTO "func_key_template" (tenant_uuid, private) VALUES ('4a037de3-94bd-4d40-b4d1-3fc09184c3d2', TRUE);
-INSERT INTO "userfeatures" (uuid, firstname, email, description, func_key_private_template_id, tenant_uuid)
-VALUES
-(1, 'Alice', 'awonderland@wazo-auth.com', '', 1, '4a037de3-94bd-4d40-b4d1-3fc09184c3d2');

--- a/integration_tests/assets/postgres_data/populate.ldap.sql
+++ b/integration_tests/assets/postgres_data/populate.ldap.sql
@@ -1,5 +1,10 @@
 INSERT INTO "tenant" (uuid) VALUES ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid)) ON CONFLICT DO NOTHING;
-INSERT INTO "func_key_template" (tenant_uuid, private) VALUES ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid), TRUE);
+INSERT INTO "func_key_template" (tenant_uuid, private) VALUES
+    ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid), TRUE),
+    ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid), TRUE),
+    ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid), TRUE);
 INSERT INTO "userfeatures" (uuid, firstname, email, description, func_key_private_template_id, tenant_uuid)
 VALUES
-(1, 'Alice', 'awonderland@wazo-auth.com', '', 1, (SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid));
+(1, 'Alice', 'awonderland@wazo-auth.com', '', 1, (SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid)),
+(2, 'Humpty', 'humptydumpty@wazo-auth.com', '', 2, (SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid)),
+(3, 'Lewis', '', '', 3, (SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid));

--- a/integration_tests/assets/postgres_data/populate.ldap.sql
+++ b/integration_tests/assets/postgres_data/populate.ldap.sql
@@ -1,10 +1,5 @@
 INSERT INTO "tenant" (uuid) VALUES ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid)) ON CONFLICT DO NOTHING;
-INSERT INTO "func_key_template" (tenant_uuid, private) VALUES
-    ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid), TRUE),
-    ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid), TRUE),
-    ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid), TRUE);
+INSERT INTO "func_key_template" (tenant_uuid, private) VALUES ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid), TRUE);
 INSERT INTO "userfeatures" (uuid, firstname, email, description, func_key_private_template_id, tenant_uuid)
 VALUES
-(1, 'Alice', 'awonderland@wazo-auth.com', '', 1, (SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid)),
-(2, 'Humpty', 'humptydumpty@wazo-auth.com', '', 2, (SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid)),
-(3, 'Lewis', '', '', 3, (SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid));
+(1, 'Alice', 'awonderland@wazo-auth.com', '', 1, (SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid));

--- a/integration_tests/assets/postgres_data/populate.ldap.sql
+++ b/integration_tests/assets/postgres_data/populate.ldap.sql
@@ -1,5 +1,0 @@
-INSERT INTO "tenant" (uuid) VALUES ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid)) ON CONFLICT DO NOTHING;
-INSERT INTO "func_key_template" (tenant_uuid, private) VALUES ((SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid), TRUE);
-INSERT INTO "userfeatures" (uuid, firstname, email, description, func_key_private_template_id, tenant_uuid)
-VALUES
-(1, 'Alice', 'awonderland@wazo-auth.com', '', 1, (SELECT uuid FROM auth_tenant WHERE uuid = parent_uuid));

--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -91,29 +91,6 @@ class _BaseLDAPTestCase(base.BaseIntegrationTest):
     username = 'admin'
     password = 's3cre7'
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        ldap_host = '127.0.0.1'
-        ldap_port = cls.asset_cls.service_port(389, 'slapd')
-        ldap_uri = f'ldap://{ldap_host}:{ldap_port}'
-        add_contacts(cls.CONTACTS, ldap_uri)
-
-
-class LDAPIntegrationTest(_BaseLDAPTestCase):
-    asset_cls = base.LDAPAssetLaunchingTestCase
-
-
-class LDAPAnonymousIntegrationTest(_BaseLDAPTestCase):
-    asset_cls = base.LDAPAnonymousAssetLaunchingTestCase
-
-
-class LDAPServiceUserIntegrationTest(_BaseLDAPTestCase):
-    asset_cls = base.LDAPServiceUserAssetLaunchingTestCase
-
-
-@base.use_asset('ldap')
-class TestLDAP(LDAPIntegrationTest):
     CONTACTS = [
         Contact(
             'Alice Wonderland',
@@ -137,6 +114,30 @@ class TestLDAP(LDAPIntegrationTest):
             'mail',
         ),
     ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ldap_host = '127.0.0.1'
+        ldap_port = cls.asset_cls.service_port(389, 'slapd')
+        ldap_uri = f'ldap://{ldap_host}:{ldap_port}'
+        add_contacts(cls.CONTACTS, ldap_uri)
+
+
+class LDAPIntegrationTest(_BaseLDAPTestCase):
+    asset_cls = base.LDAPAssetLaunchingTestCase
+
+
+class LDAPAnonymousIntegrationTest(_BaseLDAPTestCase):
+    asset_cls = base.LDAPAnonymousAssetLaunchingTestCase
+
+
+class LDAPServiceUserIntegrationTest(_BaseLDAPTestCase):
+    asset_cls = base.LDAPServiceUserAssetLaunchingTestCase
+
+
+@base.use_asset('ldap')
+class TestLDAP(LDAPIntegrationTest):
 
     def test_ldap_authentication(self):
         response = self._post_token(
@@ -168,29 +169,6 @@ class TestLDAP(LDAPIntegrationTest):
 
 @base.use_asset('ldap_anonymous')
 class TestLDAPAnonymous(LDAPAnonymousIntegrationTest):
-    CONTACTS = [
-        Contact(
-            'Alice Wonderland',
-            'awonderland',
-            'awonderland_password',
-            'awonderland@wazo-auth.com',
-            'mail',
-        ),
-        Contact(
-            'Humpty Dumpty',
-            'humptydumpty',
-            'humptydumpty_password',
-            None,
-            'uid',
-        ),
-        Contact(
-            'Lewis Carroll',
-            'lewiscarroll',
-            'lewiscarroll_password',
-            'lewiscarroll@wazo-auth.com',
-            'mail',
-        ),
-    ]
 
     def test_ldap_authentication(self):
         response = self._post_token(
@@ -222,29 +200,6 @@ class TestLDAPAnonymous(LDAPAnonymousIntegrationTest):
 
 @base.use_asset('ldap_service_user')
 class TestLDAPServiceUser(LDAPServiceUserIntegrationTest):
-    CONTACTS = [
-        Contact(
-            'Alice Wonderland',
-            'awonderland',
-            'awonderland_password',
-            'awonderland@wazo-auth.com',
-            'uid',
-        ),
-        Contact(
-            'Humpty Dumpty',
-            'humptydumpty',
-            'humptydumpty_password',
-            None,
-            'uid',
-        ),
-        Contact(
-            'Lewis Carroll',
-            'lewiscarroll',
-            'lewiscarroll_password',
-            'lewiscarroll@wazo-auth.com',
-            'mail',
-        ),
-    ]
 
     def test_ldap_authentication(self):
         response = self._post_token(

--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -138,7 +138,6 @@ class LDAPServiceUserIntegrationTest(_BaseLDAPTestCase):
 
 @base.use_asset('ldap')
 class TestLDAP(LDAPIntegrationTest):
-
     def test_ldap_authentication(self):
         response = self._post_token(
             'Alice Wonderland', 'awonderland_password', backend='ldap_user'
@@ -156,20 +155,19 @@ class TestLDAP(LDAPIntegrationTest):
         args = ('Humpty Dumpty', 'humptydumpty_password')
         assert_that(
             calling(self._post_token).with_args(*args, backend='ldap_user'),
-            raises(requests.HTTPError, pattern='401')
+            raises(requests.HTTPError, pattern='401'),
         )
 
     def test_ldap_authentication_fails_when_no_email_in_user(self):
         args = ('Lewis Carroll', 'lewiscarroll_password')
         assert_that(
             calling(self._post_token).with_args(*args, backend='ldap_user'),
-            raises(requests.HTTPError, pattern='401')
+            raises(requests.HTTPError, pattern='401'),
         )
 
 
 @base.use_asset('ldap_anonymous')
 class TestLDAPAnonymous(LDAPAnonymousIntegrationTest):
-
     def test_ldap_authentication(self):
         response = self._post_token(
             'awonderland@wazo-auth.com', 'awonderland_password', backend='ldap_user'
@@ -187,20 +185,19 @@ class TestLDAPAnonymous(LDAPAnonymousIntegrationTest):
         args = ('humptydumpty@wazo-auth.com', 'humptydumpty_password')
         assert_that(
             calling(self._post_token).with_args(*args, backend='ldap_user'),
-            raises(requests.HTTPError, pattern='401')
+            raises(requests.HTTPError, pattern='401'),
         )
 
     def test_ldap_authentication_fails_when_no_email_in_user(self):
         args = ('lewiscarroll@wazo-auth.com', 'lewiscarroll_password')
         assert_that(
             calling(self._post_token).with_args(*args, backend='ldap_user'),
-            raises(requests.HTTPError, pattern='401')
+            raises(requests.HTTPError, pattern='401'),
         )
 
 
 @base.use_asset('ldap_service_user')
 class TestLDAPServiceUser(LDAPServiceUserIntegrationTest):
-
     def test_ldap_authentication(self):
         response = self._post_token(
             'awonderland', 'awonderland_password', backend='ldap_user'
@@ -218,12 +215,12 @@ class TestLDAPServiceUser(LDAPServiceUserIntegrationTest):
         args = ('humptydumpty', 'humptydumpty_password')
         assert_that(
             calling(self._post_token).with_args(*args, backend='ldap_user'),
-            raises(requests.HTTPError, pattern='401')
+            raises(requests.HTTPError, pattern='401'),
         )
 
     def test_ldap_authentication_fails_when_no_email_in_user(self):
         args = ('lewiscarroll', 'lewiscarroll_password')
         assert_that(
             calling(self._post_token).with_args(*args, backend='ldap_user'),
-            raises(requests.HTTPError, pattern='401')
+            raises(requests.HTTPError, pattern='401'),
         )

--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -67,25 +67,6 @@ class LDAPHelper:
         self._ldap_obj.add_s(self.QUEBEC_DN, modlist)
 
 
-def add_contacts(contacts, ldap_uri):
-    for _ in range(10):
-        try:
-            helper = LDAPHelper(ldap_uri)
-            break
-        except ldap.SERVER_DOWN:
-            time.sleep(1)
-    else:
-        raise Exception('could not add contacts: LDAP server is down')
-
-    helper.add_ou()
-    helper.add_contact(Contact('wazo_auth', 'wazo_auth', 'S3cr$t', '', 'cn'), 'people')
-    for contact in contacts:
-        if not contact.mail:
-            helper.add_contact_without_email(contact, 'quebec')
-        else:
-            helper.add_contact(contact, 'quebec')
-
-
 class _BaseLDAPTestCase(base.BaseIntegrationTest):
 
     username = 'admin'
@@ -116,12 +97,31 @@ class _BaseLDAPTestCase(base.BaseIntegrationTest):
     ]
 
     @classmethod
+    def add_contacts(cls, contacts, ldap_uri):
+        for _ in range(10):
+            try:
+                helper = LDAPHelper(ldap_uri)
+                break
+            except ldap.SERVER_DOWN:
+                time.sleep(1)
+        else:
+            raise Exception('could not add contacts: LDAP server is down')
+
+        helper.add_ou()
+        helper.add_contact(Contact('wazo_auth', 'wazo_auth', 'S3cr$t', '', 'cn'), 'people')
+        for contact in contacts:
+            if not contact.mail:
+                helper.add_contact_without_email(contact, 'quebec')
+            else:
+                helper.add_contact(contact, 'quebec')
+
+    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         ldap_host = '127.0.0.1'
         ldap_port = cls.asset_cls.service_port(389, 'slapd')
         ldap_uri = f'ldap://{ldap_host}:{ldap_port}'
-        add_contacts(cls.CONTACTS, ldap_uri)
+        cls.add_contacts(cls.CONTACTS, ldap_uri)
 
 
 class LDAPIntegrationTest(_BaseLDAPTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skipsdist = true
 [testenv]
 basepython = python3.7
 commands =
-    pytest --junitxml=unit-tests.xml --cov=wazo_auth --cov-report term --cov-report xml:coverage.xml wazo_auth
+    pytest --junitxml=unit-tests.xml --cov=wazo_auth --cov-report term --cov-report xml:coverage.xml {posargs} wazo_auth
 deps =
     -rrequirements.txt
     -rtest-requirements.txt

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -1,8 +1,8 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import logging
 import ldap
+import logging
 
 from ldap.filter import escape_filter_chars
 from ldap.dn import escape_dn_chars

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -16,6 +16,7 @@ class LDAPUser(BaseAuthenticationBackend):
         super().load(dependencies)
         config = dependencies['config']
         self._user_service = dependencies['user_service']
+        self._group_service = dependencies['group_service']
         self._purposes = dependencies['purposes']
         self.config = config['ldap']
         self.uri = self.config['uri']
@@ -27,8 +28,11 @@ class LDAPUser(BaseAuthenticationBackend):
         self.user_email_attribute = self.config.get('user_email_attribute', 'mail')
 
     def get_acl(self, login, args):
-        acl = args.get('acl', [])
-        return acl
+        backend_acl = args.get('acl', [])
+        username = self._user_service.get_username_by_login(args['user_email'])
+        group_acl = self._group_service.get_acl(username)
+        user_acl = self._user_service.get_acl(username)
+        return backend_acl + group_acl + user_acl
 
     def get_metadata(self, login, args):
         metadata = super().get_metadata(login, args)

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -3,7 +3,6 @@
 
 import logging
 import ldap
-import xivo_dao
 
 from ldap.filter import escape_filter_chars
 from ldap.dn import escape_dn_chars
@@ -16,7 +15,6 @@ class LDAPUser(BaseAuthenticationBackend):
     def load(self, dependencies):
         super().load(dependencies)
         config = dependencies['config']
-        xivo_dao.init_db(config['confd_db_uri'])
         self._user_service = dependencies['user_service']
         self.config = config['ldap']
         self.uri = self.config['uri']

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -44,20 +44,20 @@ class LDAPUser(BaseAuthenticationBackend):
 
     def verify_password(self, username, password, args):
         try:
-            xivo_ldap = _XivoLDAP(self.uri)
+            wazo_ldap = _WazoLDAP(self.uri)
 
             if self.bind_anonymous or (self.bind_dn and self.bind_password):
-                if xivo_ldap.perform_bind(self.bind_dn, self.bind_password):
-                    user_dn = self._perform_search_dn(xivo_ldap, username)
+                if wazo_ldap.perform_bind(self.bind_dn, self.bind_password):
+                    user_dn = self._perform_search_dn(wazo_ldap, username)
                 else:
                     return False
             else:
                 user_dn = self._build_dn_with_config(username)
 
-            if not user_dn or not xivo_ldap.perform_bind(user_dn, password):
+            if not user_dn or not wazo_ldap.perform_bind(user_dn, password):
                 return False
 
-            user_email = self._get_user_ldap_email(xivo_ldap, user_dn)
+            user_email = self._get_user_ldap_email(wazo_ldap, user_dn)
             if not user_email:
                 return False
 
@@ -78,13 +78,13 @@ class LDAPUser(BaseAuthenticationBackend):
 
     def _get_pbx_user_uuid_by_ldap_attribute(self, user_email):
         with session_scope():
-            xivo_user = find_by(email=user_email)
-            if not xivo_user:
+            wazo_user = find_by(email=user_email)
+            if not wazo_user:
                 logger.warning(
                     '%s does not have an email associated with a PBX user', user_email
                 )
-                return xivo_user
-            return xivo_user.uuid
+                return wazo_user
+            return wazo_user.uuid
 
     def _build_dn_with_config(self, login):
         login_esc = escape_dn_chars(login)
@@ -92,8 +92,8 @@ class LDAPUser(BaseAuthenticationBackend):
             self.user_login_attribute, login_esc, self.user_base_dn
         )
 
-    def _get_user_ldap_email(self, xivo_ldap, user_dn):
-        _, obj = xivo_ldap.perform_search(
+    def _get_user_ldap_email(self, wazo_ldap, user_dn):
+        _, obj = wazo_ldap.perform_search(
             user_dn, ldap.SCOPE_BASE, attrlist=[self.user_email_attribute]
         )
         email = obj.get(self.user_email_attribute, None)
@@ -102,10 +102,10 @@ class LDAPUser(BaseAuthenticationBackend):
             logger.debug('LDAP : No email found for the user DN: %s', user_dn)
         return email.decode('utf-8')
 
-    def _perform_search_dn(self, xivo_ldap, username):
+    def _perform_search_dn(self, wazo_ldap, username):
         username_esc = escape_filter_chars(username)
         filterstr = '{}={}'.format(self.user_login_attribute, username_esc)
-        dn, _ = xivo_ldap.perform_search(
+        dn, _ = wazo_ldap.perform_search(
             self.user_base_dn, ldap.SCOPE_SUBTREE, filterstr=filterstr, attrlist=['']
         )
         if not dn:
@@ -117,7 +117,7 @@ class LDAPUser(BaseAuthenticationBackend):
         return dn
 
 
-class _XivoLDAP:
+class _WazoLDAP:
     def __init__(self, uri):
         self.uri = uri
         self.ldapobj = self._create_ldap_obj(self.uri)

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -100,6 +100,7 @@ class LDAPUser(BaseAuthenticationBackend):
         email = email[0] if isinstance(email, list) else email
         if not email:
             logger.debug('LDAP : No email found for the user DN: %s', user_dn)
+            return
         return email.decode('utf-8')
 
     def _perform_search_dn(self, wazo_ldap, username):

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -7,7 +7,7 @@ import ldap
 from mock import patch, Mock, call
 from hamcrest import assert_that, empty, equal_to, has_entries
 
-from wazo_auth.plugins.backends.ldap_user import LDAPUser, _XivoLDAP
+from wazo_auth.plugins.backends.ldap_user import LDAPUser, _WazoLDAP
 
 
 @patch('wazo_auth.plugins.backends.ldap_user.find_by')
@@ -56,7 +56,7 @@ class TestGetMetadata(unittest.TestCase):
         self.assertRaises(Exception, self.backend.get_metadata, 'alice', None)
 
 
-@patch('wazo_auth.plugins.backends.ldap_user._XivoLDAP')
+@patch('wazo_auth.plugins.backends.ldap_user._WazoLDAP')
 @patch('wazo_auth.plugins.backends.ldap_user.find_by')
 class TestVerifyPassword(unittest.TestCase):
     def setUp(self):
@@ -75,59 +75,59 @@ class TestVerifyPassword(unittest.TestCase):
         obj.return_value.mail.return_value = self.expected_user_email
         self.search_obj_result = (self.expected_user_dn, obj)
 
-    def test_that_verify_password_return_false_when_ldaperror(self, find_by, xivo_ldap):
+    def test_that_verify_password_return_false_when_ldaperror(self, find_by, wazo_ldap):
         backend = LDAPUser()
         backend.load({'config': self.config})
-        xivo_ldap.side_effect = ldap.LDAPError
+        wazo_ldap.side_effect = ldap.LDAPError
         args = {}
 
         result = backend.verify_password('foo', 'bar', args)
         assert_that(result, equal_to(False))
 
     def test_that_verify_password_return_false_when_serverdown(
-        self, find_by, xivo_ldap
+        self, find_by, wazo_ldap
     ):
         backend = LDAPUser()
         backend.load({'config': self.config})
-        xivo_ldap.side_effect = ldap.SERVER_DOWN
+        wazo_ldap.side_effect = ldap.SERVER_DOWN
         args = {}
 
         result = backend.verify_password('foo', 'bar', args)
         assert_that(result, equal_to(False))
 
-    def test_that_verify_password_calls_perform_bind(self, find_by, xivo_ldap):
+    def test_that_verify_password_calls_perform_bind(self, find_by, wazo_ldap):
         backend = LDAPUser()
         backend.load({'config': self.config})
 
-        xivo_ldap = xivo_ldap.return_value
-        xivo_ldap.perform_bind.return_value = True
-        xivo_ldap.perform_search.return_value = self.search_obj_result
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = self.search_obj_result
         find_by.return_value.uuid = 'alice-uuid'
         args = {}
 
         result = backend.verify_password('foo', 'bar', args)
 
         assert_that(result, equal_to(True))
-        xivo_ldap.perform_bind.assert_called_once_with(self.expected_user_dn, 'bar')
+        wazo_ldap.perform_bind.assert_called_once_with(self.expected_user_dn, 'bar')
 
-    def test_that_verify_password_escape_dn_chars(self, find_by, xivo_ldap):
+    def test_that_verify_password_escape_dn_chars(self, find_by, wazo_ldap):
         backend = LDAPUser()
         backend.load({'config': self.config})
 
-        xivo_ldap = xivo_ldap.return_value
-        xivo_ldap.perform_bind.return_value = True
-        xivo_ldap.perform_search.return_value = ('uid=fo\\+o,dc=example,dc=com', Mock())
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = ('uid=fo\\+o,dc=example,dc=com', Mock())
         find_by.return_value.uuid = 'alice-uuid'
         args = {}
 
         result = backend.verify_password('fo+o', 'bar', args)
 
         assert_that(result, equal_to(True))
-        xivo_ldap.perform_bind.assert_called_once_with(
+        wazo_ldap.perform_bind.assert_called_once_with(
             'uid=fo\\+o,dc=example,dc=com', 'bar'
         )
 
-    def test_that_verify_password_escape_filter_chars(self, find_by, xivo_ldap):
+    def test_that_verify_password_escape_filter_chars(self, find_by, wazo_ldap):
         extended_config = {
             'confd_db_uri': 'postgresql:///',
             'ldap': {'bind_anonymous': True},
@@ -136,41 +136,41 @@ class TestVerifyPassword(unittest.TestCase):
         backend = LDAPUser()
         backend.load({'config': self.config})
 
-        xivo_ldap = xivo_ldap.return_value
-        xivo_ldap.perform_bind.return_value = True
-        xivo_ldap.perform_search.return_value = ('uid=fo\\+o,dc=example,dc=com', Mock())
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = ('uid=fo\\+o,dc=example,dc=com', Mock())
         find_by.return_value.uuid = 'alice-uuid'
         args = {}
 
         result = backend.verify_password('fo+o', 'bar', args)
 
         assert_that(result, equal_to(True))
-        xivo_ldap.perform_search.assert_called_once_with(
+        wazo_ldap.perform_search.assert_called_once_with(
             'uid=fo\\+o,dc=example,dc=com', 0, attrlist=['mail']
         )
 
     def test_that_verify_password_calls_return_false_when_no_user_bind(
-        self, find_by, xivo_ldap
+        self, find_by, wazo_ldap
     ):
         backend = LDAPUser()
         backend.load({'config': self.config})
-        xivo_ldap = xivo_ldap.return_value
-        xivo_ldap.perform_bind.return_value = False
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = False
         args = {}
 
         result = backend.verify_password('foo', 'bar', args)
 
         assert_that(result, equal_to(False))
-        xivo_ldap.perform_bind.assert_called_once_with(self.expected_user_dn, 'bar')
+        wazo_ldap.perform_bind.assert_called_once_with(self.expected_user_dn, 'bar')
 
     def test_that_verify_password_calls_return_False_when_no_email_associated(
-        self, find_by, xivo_ldap
+        self, find_by, wazo_ldap
     ):
         backend = LDAPUser()
         backend.load({'config': self.config})
-        xivo_ldap = xivo_ldap.return_value
-        xivo_ldap.perform_bind.return_value = True
-        xivo_ldap.perform_search.return_value = self.search_obj_result
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = self.search_obj_result
         find_by.return_value.uuid = None
         args = {}
 
@@ -179,7 +179,7 @@ class TestVerifyPassword(unittest.TestCase):
         assert_that(result, equal_to(False))
         assert_that(args, equal_to({}))
 
-    def test_that_verify_password_calls_with_bind_anonymous(self, find_by, xivo_ldap):
+    def test_that_verify_password_calls_with_bind_anonymous(self, find_by, wazo_ldap):
         extended_config = {
             'confd': {},
             'confd_db_uri': 'postgresql:///',
@@ -188,9 +188,9 @@ class TestVerifyPassword(unittest.TestCase):
         extended_config['ldap'].update(self.config['ldap'])
         backend = LDAPUser()
         backend.load({'config': extended_config})
-        xivo_ldap = xivo_ldap.return_value
-        xivo_ldap.perform_bind.return_value = True
-        xivo_ldap.perform_search.return_value = self.search_obj_result
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = self.search_obj_result
         find_by.return_value.uuid = 'alice-uuid'
         args = {}
 
@@ -199,10 +199,10 @@ class TestVerifyPassword(unittest.TestCase):
         assert_that(result, equal_to(True))
         assert_that(args, equal_to({'pbx_user_uuid': 'alice-uuid'}))
         expected_call = [call('', ''), call(self.expected_user_dn, 'bar')]
-        xivo_ldap.perform_bind.assert_has_calls(expected_call)
+        wazo_ldap.perform_bind.assert_has_calls(expected_call)
 
     def test_that_verify_password_calls_return_false_when_no_binding_with_anonymous(
-        self, find_by, xivo_ldap
+        self, find_by, wazo_ldap
     ):
         extended_config = {
             'confd': {},
@@ -210,18 +210,18 @@ class TestVerifyPassword(unittest.TestCase):
             'ldap': {'bind_anonymous': True},
         }
         extended_config['ldap'].update(self.config['ldap'])
-        xivo_ldap = xivo_ldap.return_value
+        wazo_ldap = wazo_ldap.return_value
         backend = LDAPUser()
         backend.load({'config': extended_config})
-        xivo_ldap.perform_bind.return_value = False
+        wazo_ldap.perform_bind.return_value = False
         args = {}
 
         result = backend.verify_password('foo', 'bar', args)
 
         assert_that(result, equal_to(False))
-        xivo_ldap.perform_bind.assert_called_once_with('', '')
+        wazo_ldap.perform_bind.assert_called_once_with('', '')
 
-    def test_that_verify_password_calls_with_bind_dn(self, find_by, xivo_ldap):
+    def test_that_verify_password_calls_with_bind_dn(self, find_by, wazo_ldap):
         extended_config = {
             'confd': {},
             'confd_db_uri': 'postgresql:///',
@@ -230,9 +230,9 @@ class TestVerifyPassword(unittest.TestCase):
         extended_config['ldap'].update(self.config['ldap'])
         backend = LDAPUser()
         backend.load({'config': extended_config})
-        xivo_ldap = xivo_ldap.return_value
-        xivo_ldap.perform_bind.return_value = True
-        xivo_ldap.perform_search.return_value = self.search_obj_result
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = self.search_obj_result
         find_by.return_value.uuid = 'alice-uuid'
         args = {}
 
@@ -244,10 +244,10 @@ class TestVerifyPassword(unittest.TestCase):
             call('uid=foo,dc=example,dc=com', 'S3cr$t'),
             call(self.expected_user_dn, 'bar'),
         ]
-        xivo_ldap.perform_bind.assert_has_calls(expected_call)
+        wazo_ldap.perform_bind.assert_has_calls(expected_call)
 
     def test_that_verify_password_calls_with_missing_bind_password_try_bind(
-        self, find_by, xivo_ldap
+        self, find_by, wazo_ldap
     ):
         extended_config = {
             'confd': {},
@@ -257,9 +257,9 @@ class TestVerifyPassword(unittest.TestCase):
         extended_config['ldap'].update(self.config['ldap'])
         backend = LDAPUser()
         backend.load({'config': extended_config})
-        xivo_ldap = xivo_ldap.return_value
-        xivo_ldap.perform_bind.return_value = True
-        xivo_ldap.perform_search.return_value = self.search_obj_result
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = self.search_obj_result
         find_by.return_value.uuid = 'alice-uuid'
         args = {}
 
@@ -267,10 +267,10 @@ class TestVerifyPassword(unittest.TestCase):
 
         assert_that(result, equal_to(True))
         assert_that(args, equal_to({'pbx_user_uuid': 'alice-uuid'}))
-        xivo_ldap.perform_bind.assert_called_once_with(self.expected_user_dn, 'bar')
+        wazo_ldap.perform_bind.assert_called_once_with(self.expected_user_dn, 'bar')
 
 
-class TestXivoLDAP(unittest.TestCase):
+class TestWazoLDAP(unittest.TestCase):
     def setUp(self):
         self.config = {
             'uri': 'ldap://host:389',
@@ -279,10 +279,10 @@ class TestXivoLDAP(unittest.TestCase):
         }
 
     @patch('ldap.initialize')
-    def test_xivo_ldap_init(self, ldap_initialize):
+    def test_wazo_ldap_init(self, ldap_initialize):
         ldapobj = ldap_initialize.return_value = Mock()
 
-        _XivoLDAP(self.config['uri'])
+        _WazoLDAP(self.config['uri'])
 
         ldap_initialize.assert_called_once_with(self.config['uri'])
         ldapobj.set_option.assert_any_call(ldap.OPT_REFERRALS, 0)
@@ -291,9 +291,9 @@ class TestXivoLDAP(unittest.TestCase):
 
     @patch('ldap.initialize', Mock())
     def test_that_perform_bind(self):
-        xivo_ldap = _XivoLDAP(self.config)
+        wazo_ldap = _WazoLDAP(self.config)
 
-        result = xivo_ldap.perform_bind('username', 'password')
+        result = wazo_ldap.perform_bind('username', 'password')
         self.assertEqual(result, True)
 
     @patch('ldap.initialize')
@@ -302,18 +302,18 @@ class TestXivoLDAP(unittest.TestCase):
     ):
         ldapobj = ldap_initialize.return_value = Mock()
 
-        xivo_ldap = _XivoLDAP(self.config)
+        wazo_ldap = _WazoLDAP(self.config)
         ldapobj.simple_bind_s.side_effect = ldap.INVALID_CREDENTIALS()
-        result = xivo_ldap.perform_bind('username', 'password')
+        result = wazo_ldap.perform_bind('username', 'password')
         self.assertEqual(result, False)
 
     @patch('ldap.initialize')
     def test_that_perform_search(self, ldap_initialize):
         ldapobj = ldap_initialize.return_value = Mock()
-        xivo_ldap = _XivoLDAP(self.config)
+        wazo_ldap = _WazoLDAP(self.config)
         ldapobj.search_ext_s.return_value = ['result1']
 
-        result = xivo_ldap.perform_search('base', 'scope')
+        result = wazo_ldap.perform_search('base', 'scope')
         self.assertEqual(result, 'result1')
 
     @patch('ldap.initialize')
@@ -321,19 +321,19 @@ class TestXivoLDAP(unittest.TestCase):
         self, ldap_initialize
     ):
         ldapobj = ldap_initialize.return_value = Mock()
-        xivo_ldap = _XivoLDAP(self.config)
+        wazo_ldap = _WazoLDAP(self.config)
         ldapobj.search_ext_s.side_effect = ldap.SIZELIMIT_EXCEEDED()
 
-        result_dn, result_attr = xivo_ldap.perform_search('base', 'scope')
+        result_dn, result_attr = wazo_ldap.perform_search('base', 'scope')
         self.assertEqual(result_dn, None)
         self.assertEqual(result_attr, None)
 
     @patch('ldap.initialize')
     def test_that_perform_search_return_none_when_no_result(self, ldap_initialize):
         ldapobj = ldap_initialize.return_value = Mock()
-        xivo_ldap = _XivoLDAP(self.config)
+        wazo_ldap = _WazoLDAP(self.config)
         ldapobj.search_ext_s.return_value = []
 
-        result_dn, result_attr = xivo_ldap.perform_search('base', 'scope')
+        result_dn, result_attr = wazo_ldap.perform_search('base', 'scope')
         self.assertEqual(result_dn, None)
         self.assertEqual(result_attr, None)

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -13,8 +13,6 @@ from wazo_auth.plugins.backends.ldap_user import LDAPUser, _WazoLDAP
 class TestGetACLS(unittest.TestCase):
     def setUp(self):
         config = {
-            'confd': {},
-            'confd_db_uri': 'postgresql:///',
             'ldap': {
                 'uri': 'ldap://host:389',
                 'user_base_dn': 'dc=example,dc=com',
@@ -35,8 +33,6 @@ class TestGetACLS(unittest.TestCase):
 class TestGetMetadata(unittest.TestCase):
     def setUp(self):
         config = {
-            'confd': {},
-            'confd_db_uri': 'postgresql:///',
             'ldap': {
                 'uri': 'ldap://host:389',
                 'user_base_dn': 'dc=example,dc=com',
@@ -62,8 +58,6 @@ class TestGetMetadata(unittest.TestCase):
 class TestVerifyPassword(unittest.TestCase):
     def setUp(self):
         self.config = {
-            'confd': {},
-            'confd_db_uri': 'postgresql:///',
             'ldap': {
                 'uri': 'ldap://host:389',
                 'user_base_dn': 'dc=example,dc=com',
@@ -129,10 +123,7 @@ class TestVerifyPassword(unittest.TestCase):
         )
 
     def test_that_verify_password_escape_filter_chars(self, wazo_ldap):
-        extended_config = {
-            'confd_db_uri': 'postgresql:///',
-            'ldap': {'bind_anonymous': True},
-        }
+        extended_config = {'ldap': {'bind_anonymous': True}}
         extended_config['ldap'].update(self.config['ldap'])
         backend = LDAPUser()
         backend.load({'config': self.config, 'user_service': self.user_service})
@@ -179,11 +170,7 @@ class TestVerifyPassword(unittest.TestCase):
         assert_that(args, equal_to({}))
 
     def test_that_verify_password_calls_with_bind_anonymous(self, wazo_ldap):
-        extended_config = {
-            'confd': {},
-            'confd_db_uri': 'postgresql:///',
-            'ldap': {'bind_anonymous': True},
-        }
+        extended_config = {'ldap': {'bind_anonymous': True}}
         extended_config['ldap'].update(self.config['ldap'])
         backend = LDAPUser()
         backend.load({'config': extended_config, 'user_service': self.user_service})
@@ -203,11 +190,7 @@ class TestVerifyPassword(unittest.TestCase):
     def test_that_verify_password_calls_return_false_when_no_binding_with_anonymous(
         self, wazo_ldap
     ):
-        extended_config = {
-            'confd': {},
-            'confd_db_uri': 'postgresql:///',
-            'ldap': {'bind_anonymous': True},
-        }
+        extended_config = {'ldap': {'bind_anonymous': True}}
         extended_config['ldap'].update(self.config['ldap'])
         wazo_ldap = wazo_ldap.return_value
         backend = LDAPUser()
@@ -222,8 +205,6 @@ class TestVerifyPassword(unittest.TestCase):
 
     def test_that_verify_password_calls_with_bind_dn(self, wazo_ldap):
         extended_config = {
-            'confd': {},
-            'confd_db_uri': 'postgresql:///',
             'ldap': {'bind_dn': 'uid=foo,dc=example,dc=com', 'bind_password': 'S3cr$t'},
         }
         extended_config['ldap'].update(self.config['ldap'])
@@ -248,11 +229,7 @@ class TestVerifyPassword(unittest.TestCase):
     def test_that_verify_password_calls_with_missing_bind_password_try_bind(
         self, wazo_ldap
     ):
-        extended_config = {
-            'confd': {},
-            'confd_db_uri': 'postgresql:///',
-            'ldap': {'bind_dn': 'uid=foo,dc=example,dc=com'},
-        }
+        extended_config = {'ldap': {'bind_dn': 'uid=foo,dc=example,dc=com'}}
         extended_config['ldap'].update(self.config['ldap'])
         backend = LDAPUser()
         backend.load({'config': extended_config, 'user_service': self.user_service})

--- a/wazo_auth/plugins/http/tokens/api.yml
+++ b/wazo_auth/plugins/http/tokens/api.yml
@@ -377,7 +377,7 @@ definitions:
               The UUID of the matching wazo-confd user if there is one. This
               field can be null.
 
-              This field yould NOT be used anymore, the "pbx_user_uuid" in the
+              This field should NOT be used anymore, the "pbx_user_uuid" in the
               metadata field is the prefered method to access this information.
           xivo_uuid:
             type: string


### PR DESCRIPTION
Essentially, it is already compatible. The important part is that Microsoft uses a particular DN format.
It looks like: `CN=Firstname Lastname,DN=Users,DC=domain,DC=ext` instead of the usual `CN=Firstname Lastname,OU=People,DC=domain,DC=ext`
However, I added some tests to support some cases I stumbled upon.