### PR TITLE
Pull request for WAZO-2678-unique-username-email

### DIFF
--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -660,3 +660,23 @@ class TestUserDAO(base.DAOTestCase):
             self.session.query(func.count(models.Email.uuid)).filter(filter_).scalar()
             > 0
         )
+
+    @fixtures.db.user(username='u1@example.com', enabled=True)
+    @fixtures.db.user(username='u2@example.com', enabled=False)
+    @fixtures.db.user(email_address='u3@example.com', email_confirmed=True)
+    @fixtures.db.user(email_address='u4@example.com', email_confirmed=False)
+    def test_login_exists(self, *_):
+        result = self._user_dao.login_exists('u1@example.com')
+        assert_that(result, equal_to(True))
+
+        result = self._user_dao.login_exists('u2@example.com')
+        assert_that(result, equal_to(True))
+
+        result = self._user_dao.login_exists('u3@example.com')
+        assert_that(result, equal_to(True))
+
+        result = self._user_dao.login_exists('u4@example.com')
+        assert_that(result, equal_to(True))
+
+        result = self._user_dao.login_exists('unknown@example.com')
+        assert_that(result, equal_to(False))

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -665,7 +665,7 @@ class TestUserDAO(base.DAOTestCase):
     @fixtures.db.user(username='u2@example.com', enabled=False)
     @fixtures.db.user(email_address='u3@example.com', email_confirmed=True)
     @fixtures.db.user(email_address='u4@example.com', email_confirmed=False)
-    def test_login_exists(self, *_):
+    def test_login_exists(self, u1, u2, u3, u4):
         result = self._user_dao.login_exists('u1@example.com')
         assert_that(result, equal_to(True))
 
@@ -679,4 +679,10 @@ class TestUserDAO(base.DAOTestCase):
         assert_that(result, equal_to(True))
 
         result = self._user_dao.login_exists('unknown@example.com')
+        assert_that(result, equal_to(False))
+
+        result = self._user_dao.login_exists('u1@example.com', ignored_user=u1)
+        assert_that(result, equal_to(False))
+
+        result = self._user_dao.login_exists('u3@example.com', ignored_user=u3)
         assert_that(result, equal_to(False))

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -654,6 +654,12 @@ class TestUserDAO(base.DAOTestCase):
             raises(exceptions.UnknownLoginException),
         )
 
+    @fixtures.db.user(username='u1@example.com')
+    @fixtures.db.user(email_address='u1@example.com', email_confirmed=True)
+    def test_get_user_uuid_by_login_returns_email_first(self, u1, u2):
+        result = self._user_dao.get_user_uuid_by_login('u1@example.com')
+        assert_that(result, equal_to(u2))
+
     @fixtures.db.user(username='u1@example.com', enabled=True)
     @fixtures.db.user(username='u2@example.com', enabled=False)
     @fixtures.db.user(email_address='u3@example.com', email_confirmed=True)

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -654,13 +654,6 @@ class TestUserDAO(base.DAOTestCase):
             raises(exceptions.UnknownLoginException),
         )
 
-    def _email_exists(self, address):
-        filter_ = models.Email.address == address
-        return (
-            self.session.query(func.count(models.Email.uuid)).filter(filter_).scalar()
-            > 0
-        )
-
     @fixtures.db.user(username='u1@example.com', enabled=True)
     @fixtures.db.user(username='u2@example.com', enabled=False)
     @fixtures.db.user(email_address='u3@example.com', email_confirmed=True)
@@ -686,3 +679,10 @@ class TestUserDAO(base.DAOTestCase):
 
         result = self._user_dao.login_exists('u3@example.com', ignored_user=u3)
         assert_that(result, equal_to(False))
+
+    def _email_exists(self, address):
+        filter_ = models.Email.address == address
+        return (
+            self.session.query(func.count(models.Email.uuid)).filter(filter_).scalar()
+            > 0
+        )

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -637,7 +637,7 @@ class TestUserDAO(base.DAOTestCase):
     @fixtures.db.user(username='u2', email_address='u2@example.com', email_confirmed=True)
     @fixtures.db.user(username='u3', email_address='u3@example.com', email_confirmed=False)
     # fmt: on
-    def test_get_username_by_login(self, u1, u2, u3):
+    def test_get_user_uuid_by_login(self, u1, u2, u3):
         result = self._user_dao.get_user_uuid_by_login('u1')
         assert_that(result, equal_to(u1))
 

--- a/integration_tests/suite/test_emails.py
+++ b/integration_tests/suite/test_emails.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_inanyorder, empty, has_entries
@@ -75,3 +75,21 @@ class TestEmails(base.APIIntegrationTest):
         assert_http_error(
             409, self.client.users.update_emails, foo['uuid'], duplicated_emails
         )
+
+    @fixtures.http.user()
+    @fixtures.http.user(username='u2@example.com')
+    @fixtures.http.user(email_address='u3@example.com')
+    def test_email_same_login(self, u1, u2, u3):
+        uuid = u1['uuid']
+
+        email = {'address': 'u2@example.com', 'main': True, 'confirmed': True}
+        assert_http_error(409, self.client.users.update_emails, uuid, [email])
+
+        email = {'address': 'u2@example.com', 'main': True, 'confirmed': False}
+        assert_http_error(409, self.client.users.update_emails, uuid, [email])
+
+        email = {'address': 'u3@example.com', 'main': True, 'confirmed': True}
+        assert_http_error(409, self.client.users.update_emails, uuid, [email])
+
+        email = {'address': 'u3@example.com', 'main': True, 'confirmed': False}
+        assert_http_error(409, self.client.users.update_emails, uuid, [email])

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -57,25 +57,6 @@ class TestTokens(base.APIIntegrationTest):
         token_data = client.token.new(expiration=1)
         assert_that(token_data, has_entries(metadata=has_entries(uuid=u2['uuid'])))
 
-    @fixtures.http.user(username='u1@example.com', email_address=None, password='pass1')
-    @fixtures.http.user(username=None, email_address='u1@example.com', password='pass2')
-    def test_that_the_email_is_preferred_than_username_to_get_a_token(self, u1, u2):
-        client = Client('localhost', port=self.auth_port, prefix=None, https=False)
-
-        client.username = 'u1@example.com'
-        client.password = 'pass1'
-        assert_that(
-            calling(client.token.new).with_args(expiration=1),
-            raises(Exception).matching(
-                has_properties(response=has_properties(status_code=401))
-            ),
-        )
-
-        client.username = 'u1@example.com'
-        client.password = 'pass2'
-        token_data = client.token.new(expiration=1)
-        assert_that(token_data, has_entries(metadata=has_entries(uuid=u2['uuid'])))
-
     @fixtures.http.user(username='foo', password='bar')
     @fixtures.http.token(
         username='foo',

--- a/integration_tests/suite/test_users.py
+++ b/integration_tests/suite/test_users.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime
@@ -233,6 +233,15 @@ class TestUsers(base.APIIntegrationTest):
             pass
         logs = self.service_logs('auth', since=time_start)
         assert_that(logs, not_(contains_string(args['password'])))
+
+    @fixtures.http.user(username='user1@example.com')
+    @fixtures.http.user(email_address='user2@example.com')
+    def test_post_with_same_login(self, *_):
+        assert_http_error(409, self.client.users.new, username='user1@example.com')
+        assert_http_error(409, self.client.users.new, username='user2@example.com')
+
+        assert_http_error(409, self.client.users.new, email_address='user1@example.com')
+        assert_http_error(409, self.client.users.new, email_address='user2@example.com')
 
     @fixtures.http.user(
         username='foobar', firstname='foo', lastname='bar', purpose='user'

--- a/integration_tests/suite/test_users.py
+++ b/integration_tests/suite/test_users.py
@@ -284,6 +284,14 @@ class TestUsers(base.APIIntegrationTest):
         result = self.client.users.edit(user_uuid, **body)
         assert_that(result, has_entries(**body))
 
+    @fixtures.http.user()
+    @fixtures.http.user(username='u2@example.com')
+    @fixtures.http.user(email_address='u3@example.com')
+    def test_put_with_same_login(self, u1, *_):
+        uuid = u1['uuid']
+        assert_http_error(409, self.client.users.edit, uuid, username='u2@example.com')
+        assert_http_error(409, self.client.users.edit, uuid, username='u3@example.com')
+
     def test_register_post(self):
         args = {
             'username': 'foobar',

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -321,7 +321,7 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
     def login_exists(self, login, ignored_user=None):
         filter_ = or_(User.username == login, Email.address == login)
         if ignored_user:
-            filter_ = and_(filter_, User.uuid != ignored_user)
+            filter_ = and_(filter_, User.uuid != str(ignored_user))
         query = self.session.query(User.uuid).outerjoin(Email).filter(filter_)
         row = query.first()
         return True if row else False

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -318,8 +318,10 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         self.session.flush()
         return emails
 
-    def login_exists(self, login):
+    def login_exists(self, login, ignored_user=None):
         filter_ = or_(User.username == login, Email.address == login)
+        if ignored_user:
+            filter_ = and_(filter_, User.uuid != ignored_user)
         query = self.session.query(User.uuid).outerjoin(Email).filter(filter_)
         row = query.first()
         return True if row else False

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -1,7 +1,7 @@
 # Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy import and_, exc, text
+from sqlalchemy import and_, or_, exc, text
 from sqlalchemy.orm import joinedload
 from .base import BaseDAO, PaginatorMixin
 from . import filters
@@ -317,6 +317,12 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
         self.session.flush()
         return emails
+
+    def login_exists(self, login):
+        filter_ = or_(User.username == login, Email.address == login)
+        query = self.session.query(User.uuid).outerjoin(Email).filter(filter_)
+        row = query.first()
+        return True if row else False
 
     def _add_user_email(self, user_uuid, args):
         args.setdefault('confirmed', False)

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -205,7 +205,7 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
     def get_credentials(self, user_uuid):
         query = self.session.query(User.password_salt, User.password_hash).filter(
             and_(
-                self.new_strict_filter(uuid=user_uuid),
+                User.uuid == user_uuid,
                 User.enabled.is_(True),
             )
         )

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -153,6 +153,20 @@ class UnknownUserException(APIException):
         super().__init__(404, msg, 'unknown-user', details, 'users')
 
 
+class UsernameLoginAlreadyExists(APIException):
+    def __init__(self, username):
+        msg = f'The login "{username}" is already used'
+        details = {'username': {'constraint_id': 'unique', 'message': msg}}
+        super().__init__(409, 'Conflict detected', 'conflict', details, 'users')
+
+
+class EmailLoginAlreadyExists(APIException):
+    def __init__(self, email):
+        msg = f'The login "{email}" is already used'
+        details = {'email_address': {'constraint_id': 'unique', 'message': msg}}
+        super().__init__(409, 'Conflict detected', 'conflict', details, 'users')
+
+
 class UnknownUserUUIDException(Exception):
     def __init__(self, user_uuid):
         msg = 'No such user: "{}"'.format(user_uuid)

--- a/wazo_auth/services/user.py
+++ b/wazo_auth/services/user.py
@@ -162,6 +162,11 @@ class UserService(BaseService):
         return self.get_user(user_uuid)
 
     def update_emails(self, user_uuid, emails):
+        for email in emails:
+            address = email['address']
+            if email and self._dao.user.login_exists(address, ignored_user=user_uuid):
+                raise exceptions.EmailLoginAlreadyExists(address)
+
         return self._dao.user.update_emails(user_uuid, emails)
 
     def user_has_sub_tenant(self, user_uuid, tenant_uuid):

--- a/wazo_auth/services/user.py
+++ b/wazo_auth/services/user.py
@@ -154,6 +154,10 @@ class UserService(BaseService):
 
     def update(self, scoping_tenant_uuid, user_uuid, **kwargs):
         self.assert_user_in_subtenant(scoping_tenant_uuid, user_uuid)
+        username = kwargs['username']
+        if username and self._dao.user.login_exists(username, ignored_user=user_uuid):
+            raise exceptions.UsernameLoginAlreadyExists(username)
+
         self._dao.user.update(user_uuid, **kwargs)
         return self.get_user(user_uuid)
 

--- a/wazo_auth/services/user.py
+++ b/wazo_auth/services/user.py
@@ -126,6 +126,14 @@ class UserService(BaseService):
         if password:
             kwargs['salt'], kwargs['hash_'] = self._encrypter.encrypt_password(password)
 
+        username = kwargs['username']
+        if username and self._dao.user.login_exists(username):
+            raise exceptions.UsernameLoginAlreadyExists(username)
+
+        email = kwargs.get('email_address')
+        if email and self._dao.user.login_exists(email):
+            raise exceptions.EmailLoginAlreadyExists(email)
+
         user = self._dao.user.create(**kwargs)
 
         tenant_uuid = kwargs['tenant_uuid']

--- a/wazo_auth/tests/test_services.py
+++ b/wazo_auth/tests/test_services.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, calling, equal_to, has_entries, not_, raises
@@ -308,6 +308,7 @@ class TestUserService(BaseServiceTestCase):
             'tenant_uuid': s.tenant_uuid,
         }
         self.user_dao.create.return_value = {'uuid': s.user_uuid}
+        self.user_dao.login_exists.return_value = False
         self.group_dao.get_all_users_group.return_value = Mock(uuid='')
 
         result = self.service.new_user(**params)


### PR DESCRIPTION
No migration has been done: The use case for having username == email from
another user is more an exception than normal behvior
In this case, on the next user update, a 409 will be prompted