### PR TITLE
add ldap_config in config.py

### DIFF
--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -40,6 +40,7 @@ _DEFAULT_CONFIG = {
         'external': True,
         'group_policy': True,
         'groups': True,
+        'ldap_config': False,
         'password_reset': True,
         'policies': True,
         'sessions': True,


### PR DESCRIPTION
why: be explicit about every plugin embedded by wazo-auth