### PR TITLE
ldap_config: remove POST in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
   * `GET /backends/ldap`
   * `PUT /backends/ldap`
-  * `POST /backends/ldap`
   * `DELETE /backends/ldap`
 
   * The `POST /0.1/token` endpoint now accepts the following body paremeters

--- a/integration_tests/suite/helpers/fixtures/http.py
+++ b/integration_tests/suite/helpers/fixtures/http.py
@@ -228,7 +228,7 @@ def ldap_config(**ldap_config_args):
             ldap_config_args.setdefault('user_email_attribute', 'mail')
 
             tenant_uuid = ldap_config_args.get('tenant_uuid', self.top_tenant_uuid)
-            ldap_config = self.client.ldap_config.create(
+            ldap_config = self.client.ldap_config.update(
                 ldap_config_args,
                 tenant_uuid=tenant_uuid,
             )

--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -137,7 +137,7 @@ class BaseLDAPIntegrationTest(base.BaseIntegrationTest):
 @base.use_asset('ldap')
 class TestLDAP(BaseLDAPIntegrationTest):
     def setUp(self):
-        ldap_config = self.client.ldap_config.create(
+        ldap_config = self.client.ldap_config.update(
             {
                 'host': 'slapd',
                 'port': 389,
@@ -219,7 +219,7 @@ class TestLDAP(BaseLDAPIntegrationTest):
 @base.use_asset('ldap')
 class TestLDAPServiceUser(BaseLDAPIntegrationTest):
     def setUp(self):
-        ldap_config = self.client.ldap_config.create(
+        ldap_config = self.client.ldap_config.update(
             {
                 'host': 'slapd',
                 'port': 389,

--- a/integration_tests/suite/test_db_ldap_config.py
+++ b/integration_tests/suite/test_db_ldap_config.py
@@ -70,11 +70,11 @@ class TestLDAPConfigDAO(base.DAOTestCase):
     def test_delete(self, tenant_uuid):
         assert_that(
             calling(self._ldap_config_dao.delete).with_args(UNKNOWN_TENANT),
-            raises(exceptions.UnknownLDAPConfigException),
+            not_(raises(Exception)),
         )
         assert_that(
             calling(self._ldap_config_dao.delete).with_args(tenant_uuid),
-            not_(raises(exceptions.UnknownLDAPConfigException)),
+            not_(raises(Exception)),
         )
         assert_that(
             calling(self._ldap_config_dao.get).with_args(tenant_uuid),

--- a/integration_tests/suite/test_ldap_config.py
+++ b/integration_tests/suite/test_ldap_config.py
@@ -24,123 +24,20 @@ class TestLDAPConfigAuth(base.APIIntegrationTest):
         base.assert_http_error(401, self.client.ldap_config.get, UNKNOWN_TENANT)
 
     def test_get_config_when_none(self):
-        base.assert_http_error(404, self.client.ldap_config.get, self.top_tenant_uuid)
-
-    def test_post_new_config(self):
-        body = {
-            'host': 'localhost',
-            'port': 386,
-            'protocol_version': 3,
-            'protocol_security': None,
-            'bind_dn': 'uid=admin,ou=people,dc=wazo-platform,dc=io',
-            'bind_password': 'super-secret',
-            'user_base_dn': 'ou=people,dc=wazo-platform,dc=io',
-            'user_login_attribute': 'uid',
-            'user_email_attribute': 'mail',
-        }
-        response = self.client.ldap_config.create(body)
-        expected = {
-            'host': 'localhost',
-            'port': 386,
-            'protocol_version': 3,
-            'protocol_security': None,
-            'bind_dn': 'uid=admin,ou=people,dc=wazo-platform,dc=io',
-            'user_base_dn': 'ou=people,dc=wazo-platform,dc=io',
-            'user_login_attribute': 'uid',
-            'user_email_attribute': 'mail',
-        }
-        assert_that(response, has_entries(**expected))
-        assert_that(response, not_(has_key('bind_password')))
-
-    def test_post_new_config_errors(self):
-        valid_body = {
-            'host': 'localhost',
-            'port': 386,
-            'protocol_version': 3,
-            'protocol_security': None,
-            'bind_dn': 'uid=admin,ou=people,dc=wazo-platform,dc=io',
-            'bind_password': 'super-secret',
-            'user_base_dn': 'ou=people,dc=wazo-platform,dc=io',
-            'user_login_attribute': 'uid',
-            'user_email_attribute': 'mail',
-        }
-        invalid_bodies_modifications = [
-            {'host': 1},
-            {'host': True},
-            {'host': 'a' * 513},
-            {'host': []},
-            {'host': {}},
-            {'host': None},
-            {'port': True},
-            {'port': 'a' * 513},
-            {'port': []},
-            {'port': {}},
-            {'port': None},
-            {'protocol_version': 'patate'},
-            {'protocol_version': True},
-            {'protocol_version': []},
-            {'protocol_version': {}},
-            {'protocol_security': 'patate'},
-            {'protocol_security': True},
-            {'protocol_security': []},
-            {'protocol_security': {}},
-            {'bind_dn': 1},
-            {'bind_dn': True},
-            {'bind_dn': 'a' * 257},
-            {'bind_dn': []},
-            {'bind_dn': {}},
-            {'bind_password': 1},
-            {'bind_password': True},
-            {'bind_password': []},
-            {'bind_password': {}},
-            {'user_base_dn': 1},
-            {'user_base_dn': 'a' * 257},
-            {'user_base_dn': True},
-            {'user_base_dn': []},
-            {'user_base_dn': {}},
-            {'user_login_attribute': 1},
-            {'user_login_attribute': True},
-            {'user_login_attribute': 'a' * 65},
-            {'user_login_attribute': []},
-            {'user_login_attribute': {}},
-            {'user_email_attribute': 1},
-            {'user_email_attribute': True},
-            {'user_email_attribute': 'a' * 65},
-            {'user_email_attribute': []},
-            {'user_email_attribute': {}},
-        ]
-
-        for invalid_modification in invalid_bodies_modifications:
-            body_copy = valid_body.copy()
-            body_copy.update(invalid_modification)
-            base.assert_http_error(400, self.client.ldap_config.create, body_copy)
-
-    @fixtures.http.ldap_config()
-    def test_post_config_when_already_exists(self, _):
-        new_body = {
-            'host': 'patate',
-            'port': 689,
-            'protocol_version': 2,
-            'protocol_security': 'ldaps',
-            'bind_dn': 'uid=root,ou=people,dc=wazo-platform,dc=io',
-            'bind_password': 'not-so-super-secret',
-            'user_base_dn': 'ou=genses,dc=wazo-platform,dc=io',
-            'user_login_attribute': 'cn',
-            'user_email_attribute': 'email',
-        }
-        result = self.client.ldap_config.create(new_body)
-        expected = {
-            'host': 'patate',
-            'port': 689,
-            'protocol_version': 2,
-            'protocol_security': 'ldaps',
-            'bind_dn': 'uid=root,ou=people,dc=wazo-platform,dc=io',
-            'user_base_dn': 'ou=genses,dc=wazo-platform,dc=io',
-            'user_login_attribute': 'cn',
-            'user_email_attribute': 'email',
-        }
-        assert_that(result, has_entries(**expected))
-        assert_that(result, not_(has_key('bind_password')))
+        response = self.client.ldap_config.get(self.top_tenant_uuid)
+        assert_that(
+            response,
+            has_entries(
+                host=None,
+                port=None,
+                protocol_version=None,
+                protocol_security=None,
+                bind_dn=None,
+                user_base_dn=None,
+                user_login_attribute=None,
+                user_email_attribute=None,
+            ),
+        )
 
     def test_put_new_config(self):
         body = {

--- a/integration_tests/suite/test_ldap_config.py
+++ b/integration_tests/suite/test_ldap_config.py
@@ -155,6 +155,27 @@ class TestLDAPConfigAuth(base.APIIntegrationTest):
         assert_that(result, has_entries(**expected))
         assert_that(result, not_(has_key('bind_password')))
 
+    def test_put_config_minimal_fields(self):
+        body = {
+            'host': 'patate',
+            'port': 689,
+            'user_base_dn': 'ou=genses,dc=wazo-platform,dc=io',
+            'user_login_attribute': 'cn',
+            'user_email_attribute': 'email',
+        }
+        result = self.client.ldap_config.update(body)
+        expected = {
+            'host': 'patate',
+            'port': 689,
+            'protocol_version': 3,
+            'protocol_security': None,
+            'bind_dn': None,
+            'user_base_dn': 'ou=genses,dc=wazo-platform,dc=io',
+            'user_login_attribute': 'cn',
+            'user_email_attribute': 'email',
+        }
+        assert_that(result, has_entries(**expected))
+
     @fixtures.http.ldap_config()
     def test_put_multi_tenant(self, ldap_config):
         with self.client_in_subtenant() as (client, _, tenant):

--- a/integration_tests/suite/test_ldap_config.py
+++ b/integration_tests/suite/test_ldap_config.py
@@ -166,4 +166,4 @@ class TestLDAPConfigAuth(base.APIIntegrationTest):
         base.assert_no_error(self.client.ldap_config.delete)
 
     def test_delete_config_when_none_exists(self):
-        base.assert_http_error(404, self.client.ldap_config.delete)
+        base.assert_no_error(self.client.ldap_config.delete)

--- a/wazo_auth/database/queries/ldap_config.py
+++ b/wazo_auth/database/queries/ldap_config.py
@@ -79,14 +79,8 @@ class LDAPConfigDAO(BaseDAO):
 
     def delete(self, tenant_uuid):
         filter_ = LDAPConfig.tenant_uuid == str(tenant_uuid)
-        nb_deleted = (
-            self.session.query(LDAPConfig)
-            .filter(filter_)
-            .delete(synchronize_session=False)
-        )
+        self.session.query(LDAPConfig).filter(filter_).delete(synchronize_session=False)
         self.session.flush()
-        if nb_deleted < 1:
-            raise exceptions.UnknownLDAPConfigException(tenant_uuid)
 
     def exists(self, tenant_uuid):
         filter_ = LDAPConfig.tenant_uuid == str(tenant_uuid)

--- a/wazo_auth/plugins/http/ldap_config/api.yml
+++ b/wazo_auth/plugins/http/ldap_config/api.yml
@@ -5,7 +5,9 @@ paths:
         - wazo_auth_token: []
       produces:
         - application/json
-      summary: Get current tenant's LDAP backend configuration.
+      summary: |
+        Get current tenant's LDAP backend configuration. If there is no configuration,
+        all the fields will be `null`.
       description: '**Required ACL:** `auth.backends.ldap.read`'
       operationId: getLDAPBackendConfig
       tags:
@@ -15,39 +17,6 @@ paths:
       responses:
         '200':
           description: The LDAP backend configuration
-          schema:
-            $ref: '#/definitions/LDAPBackendConfig'
-        '404':
-          description: Configuration not found for this tenant
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/Error'
-    post:
-      security:
-        - wazo_auth_token: []
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      summary: Create current tenant's LDAP backend configuration
-      description: '**Required ACL:** `auth.backends.ldap.create`'
-      operationId: createLDAPBackendConfig
-      tags:
-        - backends
-      parameters:
-        - $ref: '#/parameters/tenantuuid'
-        - name: body
-          in: body
-          description: The LDAP backend configuration
-          required: true
-          schema:
-            $ref: '#/definitions/LDAPBackendConfigEdit'
-      responses:
-        '200':
-          description: The LDAP backend configuration has been created
           schema:
             $ref: '#/definitions/LDAPBackendConfig'
         '401':

--- a/wazo_auth/plugins/http/ldap_config/http.py
+++ b/wazo_auth/plugins/http/ldap_config/http.py
@@ -22,10 +22,6 @@ class LDAPConfig(AuthResource):
         scoping_tenant = Tenant.autodetect()
         return ldap_config_schema.dump(self._ldap_service.get(scoping_tenant.uuid)), 200
 
-    @required_acl('auth.backends.ldap.create')
-    def post(self):
-        return self.put()
-
     @required_acl('auth.backends.ldap.update')
     def put(self):
         scoping_tenant = Tenant.autodetect()

--- a/wazo_auth/plugins/http/ldap_config/schemas.py
+++ b/wazo_auth/plugins/http/ldap_config/schemas.py
@@ -10,10 +10,11 @@ class LDAPConfig(BaseSchema):
     tenant_uuid = fields.String(dump_only=True, default=None)
     host = fields.String(validate=Length(max=512), required=True, default=None)
     port = fields.Integer(required=True, default=None)
-    protocol_version = fields.Integer(validate=Range(min=2, max=3), default=None)
+    protocol_version = fields.Integer(
+        validate=Range(min=2, max=3), missing=3, default=None
+    )
     protocol_security = fields.String(
         validate=OneOf(['ldaps', 'tls']),
-        missing=None,
         allow_none=True,
         default=None,
     )

--- a/wazo_auth/plugins/http/ldap_config/schemas.py
+++ b/wazo_auth/plugins/http/ldap_config/schemas.py
@@ -7,17 +7,24 @@ from xivo.mallow.validate import Length, OneOf, Range
 
 
 class LDAPConfig(BaseSchema):
-    tenant_uuid = fields.String(dump_only=True)
-    host = fields.String(validate=Length(max=512), required=True)
-    port = fields.Integer(required=True)
-    protocol_version = fields.Integer(validate=Range(min=2, max=3))
+    tenant_uuid = fields.String(dump_only=True, default=None)
+    host = fields.String(validate=Length(max=512), required=True, default=None)
+    port = fields.Integer(required=True, default=None)
+    protocol_version = fields.Integer(validate=Range(min=2, max=3), default=None)
     protocol_security = fields.String(
-        validate=OneOf(['ldaps', 'tls']), missing=None, allow_none=True
+        validate=OneOf(['ldaps', 'tls']),
+        missing=None,
+        allow_none=True,
+        default=None,
     )
-    bind_dn = fields.String(validate=Length(max=256), allow_none=True)
-    user_base_dn = fields.String(validate=Length(max=256), required=True)
-    user_login_attribute = fields.String(validate=Length(max=64), required=True)
-    user_email_attribute = fields.String(validate=Length(max=64), required=True)
+    bind_dn = fields.String(validate=Length(max=256), allow_none=True, default=None)
+    user_base_dn = fields.String(validate=Length(max=256), required=True, default=None)
+    user_login_attribute = fields.String(
+        validate=Length(max=64), required=True, default=None
+    )
+    user_email_attribute = fields.String(
+        validate=Length(max=64), required=True, default=None
+    )
 
 
 class LDAPConfigEdit(LDAPConfig):

--- a/wazo_auth/services/ldap.py
+++ b/wazo_auth/services/ldap.py
@@ -1,6 +1,7 @@
 # Copyright 2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from contextlib import suppress
 from wazo_auth.services.helpers import BaseService
 
 from .. import exceptions
@@ -21,4 +22,5 @@ class LDAPService(BaseService):
         return self._dao.ldap_config.get(kwargs['tenant_uuid'])
 
     def delete(self, tenant_uuid):
-        return self._dao.ldap_config.delete(tenant_uuid)
+        with suppress(exceptions.UnknownLDAPConfigException):
+            return self._dao.ldap_config.delete(tenant_uuid)

--- a/wazo_auth/services/ldap.py
+++ b/wazo_auth/services/ldap.py
@@ -1,7 +1,6 @@
 # Copyright 2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from contextlib import suppress
 from wazo_auth.services.helpers import BaseService
 
 from .. import exceptions
@@ -22,5 +21,4 @@ class LDAPService(BaseService):
         return self._dao.ldap_config.get(kwargs['tenant_uuid'])
 
     def delete(self, tenant_uuid):
-        with suppress(exceptions.UnknownLDAPConfigException):
-            return self._dao.ldap_config.delete(tenant_uuid)
+        return self._dao.ldap_config.delete(tenant_uuid)

--- a/wazo_auth/services/ldap.py
+++ b/wazo_auth/services/ldap.py
@@ -3,10 +3,15 @@
 
 from wazo_auth.services.helpers import BaseService
 
+from .. import exceptions
+
 
 class LDAPService(BaseService):
     def get(self, tenant_uuid):
-        return self._dao.ldap_config.get(tenant_uuid)
+        try:
+            return self._dao.ldap_config.get(tenant_uuid)
+        except exceptions.UnknownLDAPConfigException:
+            return {}
 
     def create_or_update(self, **kwargs):
         if not self._dao.ldap_config.exists(kwargs['tenant_uuid']):


### PR DESCRIPTION
Why: it does the same thing as the PUT and is not useful in that case. The GET
will return a schema with all fields set to null instead of returning a 404
when there is no config in the database.