### PR TITLE
pin markupsafe version to buster

### DIFF
--- a/integration_tests/assets/external_auth/oauth2_synchronization_service/requirements.txt
+++ b/integration_tests/assets/external_auth/oauth2_synchronization_service/requirements.txt
@@ -1,4 +1,5 @@
 flask<2
 werkzeug<2
+markupsafe<2.1  # incompatible with flask
 flask_sockets
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ itsdangerous==0.24  # from flask
 jinja2==2.10
 jsonpatch==1.21
 kombu==4.6.11
+markupsafe==1.1.0  # from flask
 marshmallow==3.0.0b14
 netifaces==0.10.4
 psycopg2==2.7.7


### PR DESCRIPTION
why: if not pinned, pip install latest version (2.1.0) which is
incompatible with flask 1.0.2 from buster