### PR TITLE
WAZO-2699: LDAP refresh token

### DIFF
--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -29,11 +29,6 @@ class LDAPUser(BaseAuthenticationBackend):
 
     def get_metadata(self, login, args):
         metadata = super().get_metadata(login, args)
-        user_data = {
-            'auth_id': args['pbx_user_uuid'],  # TODO the auth id should be the ldap id
-            'pbx_user_uuid': args['pbx_user_uuid'],
-        }
-        metadata.update(user_data)
         user_uuid = self._user_service.get_user_uuid_by_login(args['user_email'])
         purpose = self._user_service.list_users(uuid=user_uuid)[0]['purpose']
         for plugin in self._purposes.get(purpose).metadata_plugins:

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -167,7 +167,6 @@ class LDAPUser(BaseAuthenticationBackend):
         filterstr = search_filters.format(
             username=escape_filter_chars(username),
             user_login_attribute=escape_filter_chars(user_login_attribute),
-            user_base_dn=escape_filter_chars(user_base_dn),
             user_email_attribute=escape_filter_chars(user_email_attribute),
         )
 

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -20,8 +20,8 @@ class BaseTestCase(unittest.TestCase):
         ]
         self.user_service.get_acl = Mock()
         self.user_service.get_acl.return_value = ['acl1']
-        self.user_service.get_username_by_login = Mock()
-        self.user_service.get_username_by_login.return_value = 'alice'
+        self.user_service.get_user_uuid_by_login = Mock()
+        self.user_service.get_user_uuid_by_login.return_value = 'alice-uuid'
 
         self.group_service = Mock()
         self.group_service.get_acl = Mock()
@@ -47,7 +47,10 @@ class BaseTestCase(unittest.TestCase):
 
         user_metadata_plugin = Mock()
         user_metadata_plugin.get_token_metadata = Mock()
-        user_metadata_plugin.get_token_metadata.return_value = {}
+        user_metadata_plugin.get_token_metadata.return_value = {
+            'auth_id': 'alice-uuid',
+            'pbx_user_uuid': 'alice-uuid',
+        }
         user_purpose = Mock()
         user_purpose.metadata_plugins = [user_metadata_plugin]
         self.purposes = {'user': user_purpose}
@@ -98,7 +101,10 @@ class TestGetMetadata(BaseTestCase):
         )
 
     def test_that_get_metadata_calls_the_dao(self):
-        expected_result = has_entries(auth_id='alice-uuid', pbx_user_uuid='alice-uuid')
+        expected_result = has_entries(
+            auth_id='alice-uuid',
+            pbx_user_uuid='alice-uuid',
+        )
         result = self.backend.get_metadata('alice', self.args)
         assert_that(result, expected_result)
 
@@ -301,6 +307,7 @@ class TestVerifyPassword(BaseTestCase):
                     'tenant_id': 'test',
                     'pbx_user_uuid': 'alice-uuid',
                     'user_email': 'foo@example.com',
+                    'real_login': 'foo@example.com',
                 }
             ),
         )
@@ -342,6 +349,7 @@ class TestVerifyPassword(BaseTestCase):
                     'tenant_id': 'test',
                     'pbx_user_uuid': 'alice-uuid',
                     'user_email': 'foo@example.com',
+                    'real_login': 'foo@example.com',
                 }
             ),
         )

--- a/wazo_auth/plugins/http/ldap_config/api.yml
+++ b/wazo_auth/plugins/http/ldap_config/api.yml
@@ -130,8 +130,9 @@ definitions:
         type: string
         description: |
           Filters for finding a user DN given a service bind is used.
-          Available variables are `username`, `user_login_attribute`,
-          `user_email_attribute` and `user_base_dn`.
+          Available variables are `username`, `user_login_attribute` and
+          `user_email_attribute`. These variables come from the fields of the
+          same name from the API.
         example: "{user_login_attribute}={username}"
   LDAPBackendConfigEdit:
     allOf:

--- a/wazo_auth/services/token.py
+++ b/wazo_auth/services/token.py
@@ -106,7 +106,9 @@ class TokenService(BaseService):
         if args.get('access_type', 'online') == 'offline':
             body = {
                 'backend': args['backend'],
-                'login': args['login'],
+                'login': args['login']
+                if not args.get('real_login')
+                else args['real_login'],
                 'client_id': args['client_id'],
                 'user_uuid': metadata['uuid'],
                 'user_agent': args['user_agent'],


### PR DESCRIPTION
Technical details: I replace the `login` provided by the user when creating a refresh token by the one that matched during password verification in the Wazo user database.