### PR TITLE
reset email template: add the port to the query string

### DIFF
--- a/templates/password_reset_email.jinja
+++ b/templates/password_reset_email.jinja
@@ -6,6 +6,6 @@ If you did not ask to reset your password, please ignore this email.
 
 To reset your password, click on the following link:
 
-https://app.wazo.io/?host={{ hostname }}&token={{ token }}&user_uuid={{ user_uuid }}#reset-password
+https://app.wazo.io/?host={{ hostname }}{% if port %}:{{ port }}{% endif %}&token={{ token }}&user_uuid={{ user_uuid }}#reset-password
 
 The Wazo team wishes you a great day.


### PR DESCRIPTION
When using a different port to connect to the stack the port will be set and
should be sent to app.wazo.io to be able to reset the password.