### PR TITLE
WAZO-2720: LDAP service-bind fix

### DIFF
--- a/integration_tests/assets/docker-compose.base.override.yml
+++ b/integration_tests/assets/docker-compose.base.override.yml
@@ -9,7 +9,7 @@ services:
       - smtp
       - slapd
     environment:
-      TARGETS: "slapd:389 auth:9497 oauth2sync:80 postgres:5432 rabbitmq:5672 smtp:25"
+      TARGETS: "slapd:1389 auth:9497 oauth2sync:80 postgres:5432 rabbitmq:5672 smtp:25"
 
   auth:
     volumes:

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -36,13 +36,18 @@ services:
       - "5672"
 
   slapd:
-    image: nickstenning/slapd
+    image: bitnami/openldap
     environment:
-      LDAP_DOMAIN: wazo-auth.wazo.community
-      LDAP_ORGANISATION: acme
-      LDAP_ROOTPASS: wazopassword
+      BITNAMI_DEBUG: "true"
+      LDAP_PORT_NUMBER: 1389
+      LDAP_ROOT: dc=wazo-auth,dc=wazo,dc=community
+      LDAP_ADMIN_USERNAME: admin
+      LDAP_ADMIN_PASSWORD: wazopassword
+      LDAP_CONFIG_ADMIN_ENABLED: "yes"
+      LDAP_CONFIG_ADMIN_USERNAME: admin
+      LDAP_CONFIG_ADMIN_PASSWORD: configpassword
     ports:
-      - "389"
+      - "1389"
 
   smtp:
     image: munkyboy/fakesmtp

--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -260,7 +260,7 @@ class TestLDAP(BaseLDAPIntegrationTest):
         user_email_attribute='mail',
     )
     def test_ldap_authentication_multi_tenant(self, _, __, tenant2, ___):
-        args = ('lewiscarroll@wazo-auth.com', 'lewiscarroll_password')
+        args = ('Lewis Carroll', 'lewiscarroll_password')
         assert_that(
             calling(self._post_token).with_args(
                 *args, backend='ldap_user', tenant_id=tenant2['slug']

--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -18,6 +18,7 @@ Contact = namedtuple(
 
 TENANT_1_UUID = '2ec55cd6-c465-47a9-922f-569b404c48b8'
 TENANT_2_UUID = '402f2ee0-2af9-4b87-80ce-9d9e94f620e5'
+LDAP_PORT = 1389
 
 
 class LDAPHelper:
@@ -135,7 +136,7 @@ class BaseLDAPIntegrationTest(base.BaseIntegrationTest):
         super().setUpClass()
 
         ldap_host = '127.0.0.1'
-        ldap_port = cls.asset_cls.service_port(389, 'slapd')
+        ldap_port = cls.asset_cls.service_port(LDAP_PORT, 'slapd')
         ldap_uri = f'ldap://{ldap_host}:{ldap_port}'
 
         for _ in range(10):
@@ -157,7 +158,7 @@ class TestLDAP(BaseLDAPIntegrationTest):
         ldap_config = self.client.ldap_config.update(
             {
                 'host': 'slapd',
-                'port': 389,
+                'port': LDAP_PORT,
                 'user_base_dn': 'ou=quebec,ou=people,dc=wazo-auth,dc=wazo,dc=community',
                 'user_login_attribute': 'cn',
                 'user_email_attribute': 'mail',
@@ -186,7 +187,7 @@ class TestLDAP(BaseLDAPIntegrationTest):
     @fixtures.http.ldap_config(
         tenant_uuid=TENANT_2_UUID,
         host='slapd',
-        port=389,
+        port=LDAP_PORT,
         bind_dn='cn=wazo_auth,ou=people,dc=wazo-auth,dc=wazo,dc=community',
         bind_password='S3cr$t',
         user_base_dn='dc=wazo-auth,dc=wazo,dc=community',
@@ -239,7 +240,7 @@ class TestLDAPServiceUser(BaseLDAPIntegrationTest):
         ldap_config = self.client.ldap_config.update(
             {
                 'host': 'slapd',
-                'port': 389,
+                'port': LDAP_PORT,
                 'bind_dn': 'cn=wazo_auth,ou=people,dc=wazo-auth,dc=wazo,dc=community',
                 'bind_password': 'S3cr$t',
                 'user_base_dn': 'dc=wazo-auth,dc=wazo,dc=community',
@@ -271,7 +272,7 @@ class TestLDAPServiceUser(BaseLDAPIntegrationTest):
     @fixtures.http.ldap_config(
         tenant_uuid=TENANT_2_UUID,
         host='slapd',
-        port=389,
+        port=LDAP_PORT,
         bind_dn='cn=wazo_auth,ou=people,dc=wazo-auth,dc=wazo,dc=community',
         bind_password='S3cr$t',
         user_base_dn='dc=wazo-auth,dc=wazo,dc=community',
@@ -334,7 +335,7 @@ class TestLDAPRefreshToken(BaseLDAPIntegrationTest):
         ldap_config = self.client.ldap_config.update(
             {
                 'host': 'slapd',
-                'port': 389,
+                'port': LDAP_PORT,
                 'user_base_dn': 'ou=quebec,ou=people,dc=wazo-auth,dc=wazo,dc=community',
                 'user_login_attribute': 'cn',
                 'user_email_attribute': 'mail',

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ stevedore==1.29.0
 tenacity==4.12.0
 unidecode==1.0.23
 websocket-client==0.53.0
+werkzeug<2 # from flask we use a patched version of the 0.14.1 on debian buster


### PR DESCRIPTION
Explanation: the ldap object used was the same for the service bind and the mail check.
The mail retrieval was done after the user binding was done, so the ldap object was bound
to the final user account. If the user could not retrieve their email address, then it would
not work.