### PR TITLE
Add domain_names field to wazo-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ has been added to the following resources:
 
   * `tenants`
 
+supporting the following operations:
+
+  * `GET /tenants/domain_name`
+  * `PUT /tenants/{tenant_uuid}/domain_names`
+  * `DELETE /tenants/{tenant_uuid}/domain_names`
+  * `POST /tenants/{tenant_uuid}/domain_names`
+
 
 ## 22.03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 22.06
+
+* The following field:
+
+  * `domain_names`
+
+has been added to the following resources:
+
+  * `tenants`
+
+
 ## 22.03
 
 * New endpoint to get and update configuration of the LDAP authentication source:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.06
+## 22.07
 
 * The following field:
 

--- a/integration_tests/suite/test_db_tenant.py
+++ b/integration_tests/suite/test_db_tenant.py
@@ -403,3 +403,25 @@ class TestTenantDAO(base.DAOTestCase):
 
         result = self._tenant_dao._tenant_query(TENANT_UUID_2)
         assert_that(result[0], has_properties(name='2-updated'))
+
+    @fixtures.db.tenant(name='1', uuid=TENANT_UUID_1, domain_names=VALID_DOMAIN_NAMES_1)
+    def test_update_tenant_domain_names(self, *_):
+
+        self._tenant_dao.update(
+            TENANT_UUID_1, name='1-updated', domain_names=['wazo.io']
+        )
+
+        self._assert_tenant_matches(
+            TENANT_UUID_1, '1-updated', domain_names=['wazo.io']
+        )
+
+    @fixtures.db.tenant(name='1', uuid=TENANT_UUID_1, domain_names=VALID_DOMAIN_NAMES_1)
+    @fixtures.db.tenant(name='2', uuid=TENANT_UUID_2, domain_names=VALID_DOMAIN_NAMES_2)
+    def test_update_tenant_with_duplicate_domain_names_raises_409(self, *_):
+
+        assert_that(
+            calling(self._tenant_dao.update).with_args(
+                tenant_uuid=TENANT_UUID_2, domain_names=['wazo.io']
+            ),
+            raises(exceptions.DomainAlreadyExistException),
+        )

--- a/integration_tests/suite/test_db_tenant.py
+++ b/integration_tests/suite/test_db_tenant.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
@@ -371,8 +371,8 @@ class TestTenantDAO(base.DAOTestCase):
 
         if domain_names:
 
-            filter_ = models.DomainName.name.in_(domain_names)
-            names = s.query(models.DomainName.name).filter(filter_).all()
+            filter_ = models.Domain.name.in_(domain_names)
+            names = s.query(models.Domain.name).filter(filter_).all()
             names = [name[0] for name in names]
             assert_that(sorted(domain_names), equal_to(sorted(names)))
 

--- a/integration_tests/suite/test_db_tenant.py
+++ b/integration_tests/suite/test_db_tenant.py
@@ -161,7 +161,7 @@ class TestTenantDAO(base.DAOTestCase):
         result = self._tenant_dao.count(visible_tenants, domain_name='outlook.fr')
         assert_that(result, equal_to(1))
 
-        result = self._tenant_dao.count(visible_tenants, search_domain='yahoo')
+        result = self._tenant_dao.count(visible_tenants, search='yahoo')
         assert_that(result, equal_to(2))
 
     @fixtures.db.tenant(name='baz a', domain_names=VALID_DOMAIN_NAMES_1)
@@ -189,7 +189,7 @@ class TestTenantDAO(base.DAOTestCase):
         expected = build_list_matcher('bar b', 'baz a')
         assert_that(result, contains_inanyorder(*expected))
 
-        result = self._tenant_dao.list_(search_domain='yahoo')
+        result = self._tenant_dao.list_(search='yahoo')
         expected = build_list_matcher('bar b', 'foo c')
         assert_that(result, contains_inanyorder(*expected))
 

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -80,7 +80,7 @@ class TestTenants(base.APIIntegrationTest):
                 slug='slug2',
                 parent_uuid=self.top_tenant_uuid,
                 address=has_entries(**ADDRESS_NULL),
-                domain_names=sorted(VALID_DOMAIN_NAMES_2),
+                domain_names=VALID_DOMAIN_NAMES_2,
             ),
         )
 
@@ -93,7 +93,7 @@ class TestTenants(base.APIIntegrationTest):
                 phone=PHONE_1,
                 parent_uuid=self.top_tenant_uuid,
                 address=has_entries(**ADDRESS_1),
-                domain_names=sorted(VALID_DOMAIN_NAMES_1),
+                domain_names=VALID_DOMAIN_NAMES_1,
             ),
         )
 

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -80,7 +80,7 @@ class TestTenants(base.APIIntegrationTest):
                 slug='slug2',
                 parent_uuid=self.top_tenant_uuid,
                 address=has_entries(**ADDRESS_NULL),
-                domain_names=VALID_DOMAIN_NAMES_2,
+                domain_names=contains_inanyorder(*VALID_DOMAIN_NAMES_2),
             ),
         )
 
@@ -93,7 +93,7 @@ class TestTenants(base.APIIntegrationTest):
                 phone=PHONE_1,
                 parent_uuid=self.top_tenant_uuid,
                 address=has_entries(**ADDRESS_1),
-                domain_names=VALID_DOMAIN_NAMES_1,
+                domain_names=contains_inanyorder(*VALID_DOMAIN_NAMES_1),
             ),
         )
 
@@ -217,7 +217,7 @@ class TestTenants(base.APIIntegrationTest):
         name = 'My tenant'
         slug = 'my_tenant'
         tenant = self.client.tenants.new(
-            name=name, slug=slug, domain_names=sorted(VALID_DOMAIN_NAMES_1)
+            name=name, slug=slug, domain_names=VALID_DOMAIN_NAMES_1
         )
 
         def bus_received_msg():
@@ -230,7 +230,7 @@ class TestTenants(base.APIIntegrationTest):
                             data=has_entries(
                                 name=name,
                                 slug=slug,
-                                domain_names=sorted(VALID_DOMAIN_NAMES_1),
+                                domain_names=contains_inanyorder(*VALID_DOMAIN_NAMES_1),
                             ),
                         ),
                         headers=has_entry('tenant_uuid', tenant['uuid']),

--- a/wazo_auth/database/alembic/versions/0c9ccb1b16a8_add_auth_tenant_domain_name.py
+++ b/wazo_auth/database/alembic/versions/0c9ccb1b16a8_add_auth_tenant_domain_name.py
@@ -1,0 +1,43 @@
+"""add auth_tenant_domain_name
+
+Revision ID: 0c9ccb1b16a8
+Revises: a6cda77a7e3f
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0c9ccb1b16a8'
+down_revision = 'a6cda77a7e3f'
+
+TABLE_NAME = 'auth_tenant_domain_name'
+RFC_DN_MAX_LENGTH = 61
+
+
+def upgrade():
+    op.create_table(
+        TABLE_NAME,
+        Column(
+            'tenant_uuid',
+            Column(
+                sa.String(38),
+                sa.ForeignKey('auth_tenant.uuid', ondelete='CASCADE'),
+                nullable=False,
+            ),
+        ),
+        Column(
+            'name',
+            sa.String(RFC_DN_MAX_LENGTH),
+            nullable=False,
+        ),
+    )
+    op.create_unique_constraint(
+        'auth_tenant_domain_name_key', TABLE_NAME, ['name', 'tenant_uuid']
+    )
+
+
+def downgrade():
+    op.drop_constraint('auth_tenant_domain_name_key', TABLE_NAME)
+    op.drop_table(TABLE_NAME)

--- a/wazo_auth/database/alembic/versions/0c9ccb1b16a8_add_auth_tenant_domain_name.py
+++ b/wazo_auth/database/alembic/versions/0c9ccb1b16a8_add_auth_tenant_domain_name.py
@@ -38,9 +38,7 @@ def upgrade():
             unique=True,
         ),
     )
-    op.create_unique_constraint('auth_tenant_domain_name_key', TABLE_NAME, ['name'])
 
 
 def downgrade():
-    op.drop_constraint('auth_tenant_domain_name_key', TABLE_NAME)
     op.drop_table(TABLE_NAME)

--- a/wazo_auth/database/alembic/versions/0c9ccb1b16a8_add_auth_tenant_domain_name.py
+++ b/wazo_auth/database/alembic/versions/0c9ccb1b16a8_add_auth_tenant_domain_name.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 revision = '0c9ccb1b16a8'
 down_revision = 'a6cda77a7e3f'
 
-TABLE_NAME = 'auth_tenant_domain_name'
+TABLE_NAME = 'auth_tenant_domain'
 RFC_DN_MAX_LENGTH = 61
 
 

--- a/wazo_auth/database/alembic/versions/0c9ccb1b16a8_add_auth_tenant_domain_name.py
+++ b/wazo_auth/database/alembic/versions/0c9ccb1b16a8_add_auth_tenant_domain_name.py
@@ -19,23 +19,26 @@ RFC_DN_MAX_LENGTH = 61
 def upgrade():
     op.create_table(
         TABLE_NAME,
-        Column(
-            'tenant_uuid',
-            Column(
-                sa.String(38),
-                sa.ForeignKey('auth_tenant.uuid', ondelete='CASCADE'),
-                nullable=False,
-            ),
+        sa.Column(
+            'uuid',
+            sa.String(36),
+            server_default=sa.text('uuid_generate_v4()'),
+            primary_key=True,
         ),
-        Column(
+        sa.Column(
+            'tenant_uuid',
+            sa.String(38),
+            sa.ForeignKey('auth_tenant.uuid', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column(
             'name',
             sa.String(RFC_DN_MAX_LENGTH),
             nullable=False,
+            unique=True,
         ),
     )
-    op.create_unique_constraint(
-        'auth_tenant_domain_name_key', TABLE_NAME, ['name', 'tenant_uuid']
-    )
+    op.create_unique_constraint('auth_tenant_domain_name_key', TABLE_NAME, ['name'])
 
 
 def downgrade():

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -131,7 +131,7 @@ class Tenant(Base):
     contact_uuid = Column(String(38), ForeignKey('auth_user.uuid', ondelete='SET NULL'))
     parent_uuid = Column(String(38), ForeignKey('auth_tenant.uuid'), nullable=False)
     domains = relationship(
-        'DomainName', uselist=True, cascade='all, delete-orphan', backref='tenant'
+        'Domain', uselist=True, cascade='all, delete-orphan', backref='tenant'
     )
 
     @hybrid_property
@@ -153,14 +153,14 @@ class Tenant(Base):
                 domains.add(domain)
 
         for name in missing_names:
-            domains.add(DomainName(name=name, tenant=self))
+            domains.add(Domain(name=name, tenant=self))
 
         self.domains = list(domains)
 
 
-class DomainName(Base):
+class Domain(Base):
 
-    __tablename__ = 'auth_tenant_domain_name'
+    __tablename__ = 'auth_tenant_domain'
     uuid = Column(
         String(36), server_default=text('uuid_generate_v4()'), primary_key=True
     )

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -26,6 +26,8 @@ from sqlalchemy.orm import relationship
 
 Base = declarative_base()
 
+RFC_DN_MAX_LENGTH = 61
+
 
 class Address(Base):
 
@@ -128,6 +130,24 @@ class Tenant(Base):
     phone = Column(Text)
     contact_uuid = Column(String(38), ForeignKey('auth_user.uuid', ondelete='SET NULL'))
     parent_uuid = Column(String(38), ForeignKey('auth_tenant.uuid'), nullable=False)
+    domain_names = relationship('DomainName', back_populates='tenant')
+
+
+class DomainName(Base):
+
+    __tablename__ = 'auth_tenant_domain_name'
+
+    name = Column(String(RFC_DN_MAX_LENGTH), nullable=False)
+    tenant_uuid = Column(
+        String(38), ForeignKey('auth_tenant.uuid', ondelete='CASCADE'), nullable=False
+    )
+
+    tenant = relationship(
+        'Tenant',
+        back_populates='domain_names',
+        cascade='all, delete-orphan',
+        single_parent=True,
+    )
 
 
 class Token(Base):

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -130,23 +130,22 @@ class Tenant(Base):
     phone = Column(Text)
     contact_uuid = Column(String(38), ForeignKey('auth_user.uuid', ondelete='SET NULL'))
     parent_uuid = Column(String(38), ForeignKey('auth_tenant.uuid'), nullable=False)
-    domain_names = relationship('DomainName', back_populates='tenant')
+    domain_names = relationship(
+        'DomainName', uselist=True, cascade='all, delete-orphan'
+    )
 
 
 class DomainName(Base):
 
     __tablename__ = 'auth_tenant_domain_name'
 
-    name = Column(String(RFC_DN_MAX_LENGTH), nullable=False)
+    name = Column(String(RFC_DN_MAX_LENGTH), nullable=False, unique=True)
     tenant_uuid = Column(
         String(38), ForeignKey('auth_tenant.uuid', ondelete='CASCADE'), nullable=False
     )
 
-    tenant = relationship(
-        'Tenant',
-        back_populates='domain_names',
-        cascade='all, delete-orphan',
-        single_parent=True,
+    uuid = Column(
+        String(36), server_default=text('uuid_generate_v4()'), primary_key=True
     )
 
 

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -147,6 +147,11 @@ class DomainName(Base):
         String(38), ForeignKey('auth_tenant.uuid', ondelete='CASCADE'), nullable=False
     )
 
+    @property
+    def _get_name(self):
+
+        return str(self.name)
+
 
 class Token(Base):
 

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -170,11 +170,6 @@ class Domain(Base):
         String(38), ForeignKey('auth_tenant.uuid', ondelete='CASCADE'), nullable=False
     )
 
-    @property
-    def _get_name(self):
-
-        return str(self.name)
-
 
 class Token(Base):
 

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -138,14 +138,13 @@ class Tenant(Base):
 class DomainName(Base):
 
     __tablename__ = 'auth_tenant_domain_name'
+    uuid = Column(
+        String(36), server_default=text('uuid_generate_v4()'), primary_key=True
+    )
 
     name = Column(String(RFC_DN_MAX_LENGTH), nullable=False, unique=True)
     tenant_uuid = Column(
         String(38), ForeignKey('auth_tenant.uuid', ondelete='CASCADE'), nullable=False
-    )
-
-    uuid = Column(
-        String(36), server_default=text('uuid_generate_v4()'), primary_key=True
     )
 
 

--- a/wazo_auth/database/queries/filters.py
+++ b/wazo_auth/database/queries/filters.py
@@ -3,7 +3,7 @@
 
 from sqlalchemy import and_, or_, text
 from ..models import (
-    DomainName,
+    Domain,
     Email,
     ExternalAuthType,
     Group,
@@ -43,7 +43,7 @@ class _TenantSearchFilter(SearchFilter):
 
         filter_ = super().new_filter(search, **kwargs)
         pattern = self.new_pattern(search)
-        return or_(filter_, Tenant.domains.any(DomainName.name.ilike(pattern)))
+        return or_(filter_, Tenant.domains.any(Domain.name.ilike(pattern)))
 
 
 class StrictFilter:
@@ -70,7 +70,7 @@ class _TenantStrictFilter(StrictFilter):
     def new_filter(self, domain_name=None, **kwargs):
         filter_ = super().new_filter(**kwargs)
         if domain_name:
-            filter_ = and_(filter_, Tenant.domains.any(DomainName.name == domain_name))
+            filter_ = and_(filter_, Tenant.domains.any(Domain.name == domain_name))
         return filter_
 
 

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -250,10 +250,10 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
     def _slug_exist(self, slug):
         return self.session.query(Tenant.slug).filter(Tenant.slug == slug).count() > 0
 
-    def _add_domain_filters(self, search_domain=None, domain_name=None, **ignored):
+    def _add_domain_filters(self, search=None, domain_name=None, **ignored):
         filter_ = text('true')
-        if search_domain:
-            search_pattern = '%{}%'.format(search_domain)
+        if search:
+            search_pattern = '%{}%'.format(search)
             domain_name_search_filter_ = Tenant.domain_names.any(
                 DomainName.name.ilike(search_pattern)
             )

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -85,7 +85,7 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             self.session.rollback()
             if e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                 constraint = e.orig.diag.constraint_name
-                if constraint == 'auth_tenant_domain_name_name_key':
+                if constraint == 'auth_tenant_domain_name_key':
                     raise exceptions.DomainAlreadyExistException(domain_names)
                 column = self.constraint_to_column_map.get(e.orig.diag.constraint_name)
                 value = locals().get(column)
@@ -188,7 +188,7 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
                     raise exceptions.UnknownUserException(contact_uuid)
             elif e.orig.pgcode == self._UNIQUE_CONSTRAINT_CODE:
                 constraint = e.orig.diag.constraint_name
-                if constraint == 'auth_tenant_domain_name_name_key':
+                if constraint == 'auth_tenant_domain_name_key':
                     raise exceptions.DomainAlreadyExistException(domain_names)
             raise
 

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -422,12 +422,3 @@ class DomainAlreadyExistException(APIException):
         error_id = 'conflict'
         resource = 'tenants'
         super().__init__(409, 'Conflict detected', error_id, details, resource)
-
-
-class DomainNameNotFoundException(APIException):
-    def __init__(self, domain_name):
-        msg = 'Domain name : "{}" does not exist in the database'.format(domain_name)
-        details = {'domain_names': {'constraint_id': 'not-found', 'message': msg}}
-        error_id = 'unknown-domain-name'
-        resource = 'tenants'
-        super().__init__(404, 'Domain name not found', error_id, details, resource)

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -425,10 +425,8 @@ class DomainAlreadyExistException(APIException):
 
 
 class DomainNameNotFoundException(APIException):
-    def __init__(self, tenant_uuid, domain_name):
-        msg = 'Tenant : "{}" has no domain name : "{}" in its list of domain names'.format(
-            tenant_uuid, domain_name
-        )
+    def __init__(self, domain_name):
+        msg = 'Domain name : "{}" does not exist in the database'.format(domain_name)
         details = {'domain_names': {'constraint_id': 'not-found', 'message': msg}}
         error_id = 'unknown-domain-name'
         resource = 'tenants'

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -411,3 +411,25 @@ class TopTenantNotInitialized(APIException):
     def __init__(self):
         msg = 'wazo-auth top tenant is not initialized'
         super().__init__(503, msg, 'top-tenant-not-initialized')
+
+
+class DomainAlreadyExistException(APIException):
+    def __init__(self, domain_name):
+        msg = 'Domain name : "{}" is already in use, no duplicates allowed'.format(
+            domain_name
+        )
+        details = {'domain_names': {'constraint-id': 'unique', 'message': msg}}
+        error_id = 'conflict'
+        resource = 'tenants'
+        super().__init__(409, 'Conflict detected', error_id, details, resource)
+
+
+class DomainNameNotFoundException(APIException):
+    def __init__(self, tenant_uuid, domain_name):
+        msg = 'Tenant : "{}" has no domain name : "{}" in its list of domain names'.format(
+            tenant_uuid, domain_name
+        )
+        details = {'domain_names': {'constraint_id': 'not-found', 'message': msg}}
+        error_id = 'unknown-domain-name'
+        resource = 'tenants'
+        super().__init__(404, 'Domain name not found', error_id, details, resource)

--- a/wazo_auth/plugins/http/tenants/api.yml
+++ b/wazo_auth/plugins/http/tenants/api.yml
@@ -180,6 +180,12 @@ definitions:
       phone:
         type: string
         description: "The tenant's contact phone number"
+      domain_names:
+        type: array
+        description: "A list containing human readeable unique domain names, associated with a specific tenant"
+        uniqueItems: true
+        items:
+          type: string
       address:
         $ref: '#/definitions/TenantAddress'
   TenantCreate:
@@ -200,6 +206,12 @@ definitions:
       phone:
         type: string
         description: "The tenant's contact phone number"
+      domain_names:
+        type: array
+        description: "A list containing human readeable unique domain names, associated with a specific tenant"
+        uniqueItems: true
+        items:
+          type: string
       address:
         $ref: '#/definitions/TenantAddress'
   TenantEdit:
@@ -214,6 +226,12 @@ definitions:
       phone:
         type: string
         description: "The tenant's contact phone number"
+      domain_names:
+        type: array
+        description: "A list containing human readeable unique domain names, associated with a specific tenant"
+        uniqueItems: true
+        items:
+          type: string
       address:
         $ref: '#/definitions/TenantAddress'
   TenantAddress:

--- a/wazo_auth/plugins/http/tenants/api.yml
+++ b/wazo_auth/plugins/http/tenants/api.yml
@@ -5,7 +5,10 @@ paths:
         - tenants
       security:
         - wazo_auth_token: []
-      description: '**Required ACL**: `auth.tenants.read`'
+      description: |
+        **Required ACL**: `auth.tenants.read`
+
+        Tenants can be filtered by domain name using the `domain_name` query string to do an exact match on one of its domain names or using the `search` query string for a fuzzy match.
       summary: 'Retrieves the list of tenants'
       parameters:
       - $ref: '#/parameters/order'

--- a/wazo_auth/plugins/http/tenants/tests/test_tenants.py
+++ b/wazo_auth/plugins/http/tenants/tests/test_tenants.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
-from hamcrest import assert_that, equal_to, has_entries, starts_with
+from hamcrest import assert_that, equal_to, has_entries, has_value, starts_with
 from mock import ANY, Mock, patch, sentinel as s
 from wazo_auth.config import _DEFAULT_CONFIG
 from wazo_auth.tests.test_http import HTTPAppTestCase
@@ -51,7 +51,12 @@ class TestTenantPost(HTTPAppTestCase):
     def test_that_validated_args_are_passed_to_the_service(self, TenantDetector):
         TenantDetector.autodetect.return_value = Mock(uuid=s.tenant_uuid)
 
-        body = {'name': 'foobar', 'slug': 'slug', 'ignored': True}
+        body = {
+            'name': 'foobar',
+            'slug': 'slug',
+            'ignored': True,
+            'domain_names': ['wazo.io'],
+        }
         self.tenant_service.new.return_value = {
             'name': 'foobar',
             'uuid': '022035fe-f5e5-4c16-bd5f-8fea8f4c9d08',
@@ -68,6 +73,7 @@ class TestTenantPost(HTTPAppTestCase):
             phone=None,
             contact_uuid=None,
             parent_uuid=s.tenant_uuid,
+            domain_names=['wazo.io'],
             address=dict(
                 line_1=None,
                 line_2=None,
@@ -119,6 +125,110 @@ class TestTenantPost(HTTPAppTestCase):
                 ),
                 invalid_data,
             )
+
+    @patch('wazo_auth.plugins.http.tenants.http.TenantDetector')
+    def test_that_tenant_with_invalid_domain_names_returns_400(self, TenantDetector):
+        TenantDetector.autodetect.return_value = Mock(uuid=s.tenant_uuid)
+
+        invalid_datas = [
+            (
+                'domain_names',
+                {
+                    'domain_names': [
+                        '-wazo.io',
+                        ' wazo.io',
+                        '#',
+                        123,
+                        'wazo .io',
+                        'wazo.io-',
+                        'wazo',
+                        '=wazo.io',
+                        '+wazo.io',
+                        '_wazo.io',
+                        'wazo_io',
+                        'wazo_io  ',
+                        'x' * 62,
+                        None,
+                        '',
+                        [],
+                        {},
+                        ['wazo.io'],
+                    ]
+                },
+            ),
+        ]
+
+        for field, invalid_data in invalid_datas:
+            result = self.post(invalid_data)
+            assert_that(result.status_code, equal_to(400), invalid_data)
+            assert_that(
+                result.json,
+                has_entries(
+                    error_id='invalid-data',
+                    message='String does not match expected pattern.',
+                    resource='tenants',
+                    details=has_entries(
+                        field,
+                        has_value(
+                            has_entries(
+                                constraint_id='regex',
+                                constraint=ANY,
+                                message='String does not match expected pattern.',
+                            ),
+                        ),
+                    ),
+                ),
+                invalid_data,
+            )
+
+    @patch('wazo_auth.plugins.http.tenants.http.TenantDetector')
+    def test_that_post_with_duplicate_domain_names_returns_unique_ones(
+        self, TenantDetector
+    ):
+        TenantDetector.autodetect.return_value = Mock(uuid=s.tenant_uuid)
+
+        duplicate_domain_names = [
+            'wazo.io',
+            'stack.dev.wazo.io',
+            'wazo.io',
+            'gmail.com',
+            'gmail.com',
+            'gmail.ca',
+            'wazo.io',
+        ]
+
+        body = {
+            'name': 'foobar',
+            'slug': 'slug',
+            'ignored': True,
+            'domain_names': duplicate_domain_names,
+        }
+        self.tenant_service.new.return_value = {
+            'name': 'foobar',
+            'uuid': '022035fe-f5e5-4c16-bd5f-8fea8f4c9d08',
+        }
+
+        result = self.post(body)
+
+        assert_that(result.status_code, equal_to(200))
+        assert_that(result.json, equal_to(self.tenant_service.new.return_value))
+        self.tenant_service.new.assert_called_once_with(
+            uuid=None,
+            name='foobar',
+            slug='slug',
+            phone=None,
+            contact_uuid=None,
+            parent_uuid=s.tenant_uuid,
+            domain_names=sorted(list(set(duplicate_domain_names))),
+            address=dict(
+                line_1=None,
+                line_2=None,
+                city=None,
+                state=None,
+                zip_code=None,
+                country=None,
+            ),
+        )
 
     def post(self, data):
         return self.app.post(self.url, data=json.dumps(data), headers=self.headers)

--- a/wazo_auth/plugins/http/tenants/tests/test_tenants.py
+++ b/wazo_auth/plugins/http/tenants/tests/test_tenants.py
@@ -131,31 +131,20 @@ class TestTenantPost(HTTPAppTestCase):
         TenantDetector.autodetect.return_value = Mock(uuid=s.tenant_uuid)
 
         invalid_datas = [
-            (
-                'domain_names',
-                {
-                    'domain_names': [
-                        '-wazo.io',
-                        ' wazo.io',
-                        '#',
-                        123,
-                        'wazo .io',
-                        'wazo.io-',
-                        'wazo',
-                        '=wazo.io',
-                        '+wazo.io',
-                        '_wazo.io',
-                        'wazo_io',
-                        'wazo_io  ',
-                        'x' * 62,
-                        None,
-                        '',
-                        [],
-                        {},
-                        ['wazo.io'],
-                    ]
-                },
-            ),
+            ('domain_names', {'domain_names': ['-wazo.io']}),
+            ('domain_names', {'domain_names': [' wazo.io']}),
+            ('domain_names', {'domain_names': ['#']}),
+            ('domain_names', {'domain_names': ['123']}),
+            ('domain_names', {'domain_names': ['wazo .io']}),
+            ('domain_names', {'domain_names': ['wazo.io-']}),
+            ('domain_names', {'domain_names': ['wazo']}),
+            ('domain_names', {'domain_names': ['=wazo.io']}),
+            ('domain_names', {'domain_names': ['+wazo.io']}),
+            ('domain_names', {'domain_names': ['_wazo.io']}),
+            ('domain_names', {'domain_names': ['wazo_io']}),
+            ('domain_names', {'domain_names': ['wazo_io  ']}),
+            ('domain_names', {'domain_names': ['x' * 62]}),
+            ('domain_names', {'domain_names': ['']}),
         ]
 
         for field, invalid_data in invalid_datas:
@@ -165,7 +154,7 @@ class TestTenantPost(HTTPAppTestCase):
                 result.json,
                 has_entries(
                     error_id='invalid-data',
-                    message='String does not match expected pattern.',
+                    message=ANY,
                     resource='tenants',
                     details=has_entries(
                         field,

--- a/wazo_auth/plugins/http/tenants/tests/test_tenants.py
+++ b/wazo_auth/plugins/http/tenants/tests/test_tenants.py
@@ -170,6 +170,32 @@ class TestTenantPost(HTTPAppTestCase):
                 invalid_data,
             )
 
+        invalid_domains_types = [
+            ('domain_names', {'domain_names': None}),
+            ('domain_names', {'domain_names': True}),
+            ('domain_names', {'domain_names': False}),
+            ('domain_names', {'domain_names': 'wazo.community'}),
+            ('domain_names', {'domain_names': 42}),
+            ('domain_names', {'domain_names': {'name': 'wazo.community'}}),
+        ]
+
+        for field, invalid_data in invalid_domains_types:
+            result = self.post(invalid_data)
+            assert_that(result.status_code, equal_to(400), invalid_data)
+            assert_that(
+                result.json,
+                has_entries(
+                    error_id='invalid-data',
+                    message=ANY,
+                    resource='tenants',
+                    details=has_entries(
+                        field,
+                        has_entries(constraint_id=ANY, message=ANY),
+                    ),
+                ),
+                invalid_data,
+            )
+
     @patch('wazo_auth.plugins.http.tenants.http.TenantDetector')
     def test_that_post_with_duplicate_domain_names_returns_unique_ones(
         self, TenantDetector

--- a/wazo_auth/schemas.py
+++ b/wazo_auth/schemas.py
@@ -151,7 +151,7 @@ class UserSessionListSchema(BaseListSchema):
 
 
 class TenantListSchema(BaseListSchema):
-    sort_columns = ['name', 'slug', 'domain_name', 'domain_names', 'search_domain']
+    sort_columns = ['name', 'slug']
     default_sort_column = 'name'
     searchable_columns = [
         'uuid',
@@ -159,8 +159,6 @@ class TenantListSchema(BaseListSchema):
         'name',
         'slug',
         'domain_name',
-        'domain_names',
-        'search_domain',
     ]
 
 

--- a/wazo_auth/schemas.py
+++ b/wazo_auth/schemas.py
@@ -151,9 +151,17 @@ class UserSessionListSchema(BaseListSchema):
 
 
 class TenantListSchema(BaseListSchema):
-    sort_columns = ['name', 'slug']
+    sort_columns = ['name', 'slug', 'domain_name', 'domain_names', 'search_domain']
     default_sort_column = 'name'
-    searchable_columns = ['uuid', 'uuids', 'name', 'slug']
+    searchable_columns = [
+        'uuid',
+        'uuids',
+        'name',
+        'slug',
+        'domain_name',
+        'domain_names',
+        'search_domain',
+    ]
 
 
 class UserTenantListSchema(BaseListSchema):

--- a/wazo_auth/schemas.py
+++ b/wazo_auth/schemas.py
@@ -57,7 +57,7 @@ class TenantFullSchema(BaseSchema):
         fields.String(
             validate=validate.Regexp(
                 r'^([A-Za-z0-9]\.|[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]\.){1,3}[A-Za-z]{2,6}$'
-            )
+            ),
         ),
         missing=[],
         default=[],

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -102,7 +102,7 @@ class TenantService(BaseService):
             uuid=uuid,
             name=result['name'],
             slug=result['slug'],
-            domain_names=kwargs.get('domain_names', []),
+            domain_names=result['domain_names'],
         )
         self._bus_publisher.publish(event, headers={'tenant_uuid': uuid})
 

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -102,6 +102,7 @@ class TenantService(BaseService):
             uuid=uuid,
             name=result['name'],
             slug=result['slug'],
+            domain_names=kwargs.get('domain_names', []),
         )
         self._bus_publisher.publish(event, headers={'tenant_uuid': uuid})
 

--- a/wazo_auth/tests/test_schemas.py
+++ b/wazo_auth/tests/test_schemas.py
@@ -45,6 +45,7 @@ class TestTenantSchema(TestCase):
                     'slug': 'slug',
                     'contact': None,
                     'phone': None,
+                    'domain_names': [],
                     'address': {
                         'line_1': None,
                         'line_2': None,
@@ -70,6 +71,7 @@ class TestTenantSchema(TestCase):
                 uuid=uuid,
                 name=None,
                 slug='address',
+                domain_names=[],
                 address={
                     'line_1': 'here',
                     'line_2': None,


### PR DESCRIPTION
**Reason:**

As a developer, I would like to be able to set a list of domain names for my tenant.

**Constraints:**

* Must be unique,
* Must contain valid domain names,
* Must support all CRUD operations,
* Must support search for a specific domain_name