### PR TITLE
tests: don't stop upon failure

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -14,6 +14,6 @@ egg-info:
 	cd .. && python3 setup.py egg_info
 
 test:
-	pytest -x
+	pytest
 
 .PHONY: test-setup test test-image db


### PR DESCRIPTION
Why:

* We now have logs of containers in the CI, so there is no need to keep
the container to inspect logs.
* We want to know how many tests are failing