### PR TITLE
Use tenant's domain_names within LDAP authentication (/ldap_user backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 22.07
 
+The `POST /0.1/token` endpoint now accepts the following body parameters:
+
+  * `hostname`: mandatory for `ldap_user` backend
+
+The following body parameters have been deprecated on the `POST /0.1/token` endpoint:
+
+  * `tenant_id` use the `hostname` parameter instead
+
 * The following field:
 
   * `domain_names`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 The `POST /0.1/token` endpoint now accepts the following body parameters:
 
-  * `hostname`: mandatory for `ldap_user` backend
+  * `domain_name`: mandatory for `ldap_user` backend
 
 The following body parameters have been deprecated on the `POST /0.1/token` endpoint:
 
-  * `tenant_id` use the `hostname` parameter instead
+  * `tenant_id` use the `domain_name` parameter instead
 
 * The following field:
 

--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -233,7 +233,7 @@ class TestLDAP(BaseLDAPIntegrationTest):
         user_login_attribute='cn',
         user_email_attribute='mail',
     )
-    def test_ldap_authentication_with_tenant_id_and_hostname(self, tenant, user, _):
+    def test_ldap_authentication_with_tenant_id_and_domain_name(self, tenant, user, _):
         response = self._post_token(
             'Alice Wonderland',
             'awonderland_password',
@@ -258,7 +258,7 @@ class TestLDAP(BaseLDAPIntegrationTest):
             'Alice Wonderland',
             'awonderland_password',
             backend='ldap_user',
-            hostname='cust-42.myclients.com',
+            domain_name='cust-42.myclients.com',
         )
         assert_that(
             response, has_entries(metadata=has_entries(pbx_user_uuid=user['uuid']))
@@ -274,7 +274,7 @@ class TestLDAP(BaseLDAPIntegrationTest):
                 *args,
                 backend='ldap_user',
                 tenant_id=tenant['uuid'],
-                hostname='cust-42.myclients.com',
+                domain_name='cust-42.myclients.com',
             ),
             raises(requests.HTTPError, pattern='400'),
         )

--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -233,7 +233,7 @@ class TestLDAP(BaseLDAPIntegrationTest):
         user_login_attribute='cn',
         user_email_attribute='mail',
     )
-    def test_ldap_authentication_with_tenant_id_and_hostname(self, user):
+    def test_ldap_authentication_with_tenant_id_and_hostname(self, tenant, user, _):
         response = self._post_token(
             'Alice Wonderland',
             'awonderland_password',

--- a/integration_tests/suite/test_db_tenant.py
+++ b/integration_tests/suite/test_db_tenant.py
@@ -35,7 +35,7 @@ TENANT_UUID_2 = '00000000-0000-4000-a000-000000000002'
 TENANT_UUID_3 = '00000000-0000-4000-a000-000000000003'
 TENANT_UUID_4 = '00000000-0000-4000-a000-000000000004'
 
-VALID_DOMAIN_NAMES_1 = ['wazo.io', 'stack.dev.wazo.io']
+VALID_DOMAIN_NAMES_1 = ['wazo.io', 'shopify.ca']
 VALID_DOMAIN_NAMES_2 = ['gmail.com', 'yahoo.com', 'google.ca']
 VALID_DOMAIN_NAMES_3 = ['outlook.fr', 'mail.yahoo.fr']
 
@@ -150,9 +150,7 @@ class TestTenantDAO(base.DAOTestCase):
         result = self._tenant_dao.count(visible_tenants, name='b')
         assert_that(result, equal_to(1))
 
-        result = self._tenant_dao.count(
-            visible_tenants, domain_name='stack.dev.wazo.io'
-        )
+        result = self._tenant_dao.count(visible_tenants, domain_name='shopify.ca')
         assert_that(result, equal_to(1))
 
         result = self._tenant_dao.count(visible_tenants, domain_name='google.ca')

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -39,7 +39,7 @@ ADDRESS_1 = {
 }
 PHONE_1 = '555-555-5555'
 
-VALID_DOMAIN_NAMES_1 = ['wazo.io', 'stack.dev.wazo.io']
+VALID_DOMAIN_NAMES_1 = ['wazo.io', 'shopify.ca']
 VALID_DOMAIN_NAMES_2 = ['gmail.com', 'yahoo.com', 'google.ca']
 VALID_DOMAIN_NAMES_3 = ['outlook.fr', 'mail.yahoo.fr']
 

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -39,14 +39,15 @@ class LDAPUser(BaseAuthenticationBackend):
         return metadata
 
     def verify_password(self, username, password, args):
-        if 'hostname' in args:
+        if 'domain_name' in args:
             top_tenant_uuid = self._tenant_service.find_top_tenant()
             tenants = self._tenant_service.list_(
-                top_tenant_uuid, domain_name=args['hostname']
+                top_tenant_uuid, domain_name=args['domain_name']
             )
             if not tenants:
                 logger.warning(
-                    'Failed login using non-existing hostname: %s', args['hostname']
+                    'Failed login using non-existing domain_name: %s',
+                    args['domain_name'],
                 )
                 return False
             tenant_uuid = tenants[0]['uuid']
@@ -54,7 +55,7 @@ class LDAPUser(BaseAuthenticationBackend):
             # tenant_id was deprecated in wazo 22.07
             tenant_uuid = self._get_tenant(args['tenant_id'])['uuid']
             logger.warning(
-                'LDAP login using the "tenant_id" is deprecated. Use "hostname" instead'
+                'LDAP login using the "tenant_id" is deprecated. Use "domain_name" instead'
             )
 
         config = self._get_ldap_config(tenant_uuid)

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -39,7 +39,19 @@ class LDAPUser(BaseAuthenticationBackend):
         return metadata
 
     def verify_password(self, username, password, args):
-        tenant_uuid = self._get_tenant(args['tenant_id'])['uuid']
+        if 'tenant_id' in args and not 'hostname' in args:
+
+            tenant_uuid = self._get_tenant(args['tenant_id'])['uuid']
+
+        elif 'hostname' in args:
+
+            top_tenant_uuid = self._tenant_service.find_top_tenant()
+            tenants = self._tenant_service.list_(
+                top_tenant_uuid, domain_name=args['hostname']
+            )
+            if not tenants:
+                return False
+            tenant_uuid = tenants[0]['uuid']
 
         config = self._get_ldap_config(tenant_uuid)
         if not config:

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -39,12 +39,7 @@ class LDAPUser(BaseAuthenticationBackend):
         return metadata
 
     def verify_password(self, username, password, args):
-        if 'tenant_id' in args and 'hostname' not in args:
-
-            tenant_uuid = self._get_tenant(args['tenant_id'])['uuid']
-
-        elif 'hostname' in args:
-
+        if 'hostname' in args:
             top_tenant_uuid = self._tenant_service.find_top_tenant()
             tenants = self._tenant_service.list_(
                 top_tenant_uuid, domain_name=args['hostname']
@@ -55,6 +50,12 @@ class LDAPUser(BaseAuthenticationBackend):
                 )
                 return False
             tenant_uuid = tenants[0]['uuid']
+        elif 'tenant_id' in args:
+            # tenant_id was deprecated in wazo 22.07
+            tenant_uuid = self._get_tenant(args['tenant_id'])['uuid']
+            logger.warning(
+                'LDAP login using the "tenant_id" is deprecated. Use "hostname" instead'
+            )
 
         config = self._get_ldap_config(tenant_uuid)
         if not config:

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -50,6 +50,9 @@ class LDAPUser(BaseAuthenticationBackend):
                 top_tenant_uuid, domain_name=args['hostname']
             )
             if not tenants:
+                logger.warning(
+                    'Failed login using non-existing hostname: %s', args['hostname']
+                )
                 return False
             tenant_uuid = tenants[0]['uuid']
 

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -39,7 +39,7 @@ class LDAPUser(BaseAuthenticationBackend):
         return metadata
 
     def verify_password(self, username, password, args):
-        if 'tenant_id' in args and not 'hostname' in args:
+        if 'tenant_id' in args and 'hostname' not in args:
 
             tenant_uuid = self._get_tenant(args['tenant_id'])['uuid']
 

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -367,7 +367,7 @@ class TestVerifyPassword(BaseTestCase):
         )
         wazo_ldap.perform_bind.assert_called_once_with(self.expected_user_dn, 'bar')
 
-    def test_that_verify_password_works_using_hostname(self, wazo_ldap):
+    def test_that_verify_password_works_using_domain_name(self, wazo_ldap):
         backend = LDAPUser()
         backend.load(
             {
@@ -383,13 +383,13 @@ class TestVerifyPassword(BaseTestCase):
         wazo_ldap.perform_bind.return_value = True
         wazo_ldap.perform_search.return_value = self.search_obj_result
         self.list_users.return_value = [{'uuid': 'alice-uuid'}]
-        args = {'hostname': 'wazo.io'}
+        args = {'domain_name': 'wazo.io'}
 
         result = backend.verify_password('foo', 'bar', args)
 
         assert_that(result, equal_to(True))
 
-    def test_that_verify_password_using_non_existing_hostname_returns_false(
+    def test_that_verify_password_using_non_existing_domain_name_returns_false(
         self, wazo_ldap
     ):
         backend = LDAPUser()
@@ -408,7 +408,7 @@ class TestVerifyPassword(BaseTestCase):
         wazo_ldap.perform_search.return_value = self.search_obj_result
         self.list_users.return_value = [{'uuid': 'alice-uuid'}]
         self.tenant_service.list_.return_value = []
-        args = {'hostname': 'gmail.com'}
+        args = {'domain_name': 'gmail.com'}
 
         result = backend.verify_password('foo', 'bar', args)
 

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -5,7 +5,7 @@ import unittest
 import ldap
 
 from hamcrest import assert_that, equal_to, has_entries, has_items
-from mock import call, Mock, patch
+from mock import call, MagicMock, Mock, patch
 
 from wazo_auth.plugins.backends.ldap_user import LDAPUser, _WazoLDAP
 
@@ -44,6 +44,21 @@ class BaseTestCase(unittest.TestCase):
         self.tenant_service.get_by_uuid_or_slug.return_value = {
             'uuid': 'tenant-uuid-1234',
         }
+
+        self.magic_tenant_service = MagicMock()
+        self.magic_tenant_service.list_ = MagicMock()
+        self.magic_tenant_service.list_.return_value = [
+            {
+                'uuid': 'tenant-uuid-1234',
+                'domain_names': [
+                    'wazo.io',
+                    'shopify.ca',
+                    'mail.wazo.io',
+                    'stackoverflow.com',
+                ],
+                'name': '1234',
+            }
+        ]
 
         user_metadata_plugin = Mock()
         user_metadata_plugin.get_token_metadata = Mock()
@@ -354,6 +369,53 @@ class TestVerifyPassword(BaseTestCase):
             ),
         )
         wazo_ldap.perform_bind.assert_called_once_with(self.expected_user_dn, 'bar')
+
+    def test_that_verify_password_works_using_hostname(self, wazo_ldap):
+        backend = LDAPUser()
+        backend.load(
+            {
+                'user_service': self.user_service,
+                'group_service': self.group_service,
+                'ldap_service': self.ldap_service,
+                'tenant_service': self.magic_tenant_service,
+                'purposes': self.purposes,
+            }
+        )
+
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = self.search_obj_result
+        self.list_users.return_value = [{'uuid': 'alice-uuid'}]
+        args = {'hostname': 'wazo.io'}
+
+        result = backend.verify_password('foo', 'bar', args)
+
+        assert_that(result, equal_to(True))
+
+    def test_that_verify_password_using_non_existing_hostname_returns_false(
+        self, wazo_ldap
+    ):
+        backend = LDAPUser()
+        backend.load(
+            {
+                'user_service': self.user_service,
+                'group_service': self.group_service,
+                'ldap_service': self.ldap_service,
+                'tenant_service': self.magic_tenant_service,
+                'purposes': self.purposes,
+            }
+        )
+
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = self.search_obj_result
+        self.list_users.return_value = [{'uuid': 'alice-uuid'}]
+        self.magic_tenant_service.list_.return_value = []
+        args = {'hostname': 'gmail.com'}
+
+        result = backend.verify_password('foo', 'bar', args)
+
+        assert_that(result, equal_to(False))
 
 
 class TestWazoLDAP(unittest.TestCase):

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -5,7 +5,7 @@ import unittest
 import ldap
 
 from hamcrest import assert_that, equal_to, has_entries, has_items
-from mock import call, MagicMock, Mock, patch
+from mock import call, Mock, patch
 
 from wazo_auth.plugins.backends.ldap_user import LDAPUser, _WazoLDAP
 
@@ -44,10 +44,7 @@ class BaseTestCase(unittest.TestCase):
         self.tenant_service.get_by_uuid_or_slug.return_value = {
             'uuid': 'tenant-uuid-1234',
         }
-
-        self.magic_tenant_service = MagicMock()
-        self.magic_tenant_service.list_ = MagicMock()
-        self.magic_tenant_service.list_.return_value = [
+        self.tenant_service.list_.return_value = [
             {
                 'uuid': 'tenant-uuid-1234',
                 'domain_names': [
@@ -377,7 +374,7 @@ class TestVerifyPassword(BaseTestCase):
                 'user_service': self.user_service,
                 'group_service': self.group_service,
                 'ldap_service': self.ldap_service,
-                'tenant_service': self.magic_tenant_service,
+                'tenant_service': self.tenant_service,
                 'purposes': self.purposes,
             }
         )
@@ -401,7 +398,7 @@ class TestVerifyPassword(BaseTestCase):
                 'user_service': self.user_service,
                 'group_service': self.group_service,
                 'ldap_service': self.ldap_service,
-                'tenant_service': self.magic_tenant_service,
+                'tenant_service': self.tenant_service,
                 'purposes': self.purposes,
             }
         )
@@ -410,7 +407,7 @@ class TestVerifyPassword(BaseTestCase):
         wazo_ldap.perform_bind.return_value = True
         wazo_ldap.perform_search.return_value = self.search_obj_result
         self.list_users.return_value = [{'uuid': 'alice-uuid'}]
-        self.magic_tenant_service.list_.return_value = []
+        self.tenant_service.list_.return_value = []
         args = {'hostname': 'gmail.com'}
 
         result = backend.verify_password('foo', 'bar', args)

--- a/wazo_auth/plugins/http/tenants/tests/test_tenants.py
+++ b/wazo_auth/plugins/http/tenants/tests/test_tenants.py
@@ -203,7 +203,6 @@ class TestTenantPost(HTTPAppTestCase):
 
         duplicate_domain_names = [
             'wazo.io',
-            'stack.dev.wazo.io',
             'wazo.io',
             'gmail.com',
             'gmail.com',
@@ -249,16 +248,16 @@ class TestTenantPost(HTTPAppTestCase):
         TenantDetector.autodetect.return_value = Mock(uuid=s.tenant_uuid)
 
         valid_domain_names = [
-            ['stack.dev.wazo.io'],
-            ['wazo.community'],
             ['mail.yahoo.com'],
             ['mail.yahoo.fr'],
-            ['wazo.42'],
-            ['portal.staging.wazo.cloud'],
+            ['trademark247.com'],
             ['github.com'],
             ['stackoverflow.com'],
-            ['quintana.wazo.community'],
-            ['wazo-dev.atlassian.net'],
+            ['tesla.ca'],
+            ['dev.atlassian.net'],
+            ['shopify.ca'],
+            ['whatever.42'],
+            ['gmail.com'],
         ]
 
         for valid_data in valid_domain_names:

--- a/wazo_auth/plugins/http/tokens/api.yml
+++ b/wazo_auth/plugins/http/tokens/api.yml
@@ -42,6 +42,10 @@ paths:
               description: |
                 The `tenant_id` is the tenant identifier (uuid or slug) in which the token should be created. This is
                 useful only in cases where the backend used is external, i.e not `wazo_user`.
+            hostname:
+              type: string
+              description: |
+                The `hostname/domain_name` used within LDAP authentication. It must be mutually exclusive with the `tenant_id`; raises ValidationError otherwise.
             expiration:
               type: integer
             access_type:

--- a/wazo_auth/plugins/http/tokens/api.yml
+++ b/wazo_auth/plugins/http/tokens/api.yml
@@ -19,6 +19,8 @@ paths:
 
         The username/password and refresh_token method of authentication are mutually exclusive
 
+        the hostname and tenant_id must also be mutually exclusive.
+
         For more details about the backends, see http://documentation.wazo.community/en/latest/system/wazo-auth/stock_plugins.html#backends-plugins
       operationId: createToken
       tags:
@@ -37,11 +39,6 @@ paths:
             backend:
               type: string
               default: wazo_user
-            tenant_id:
-              type: string
-              description: |
-                The `tenant_id` is the tenant identifier (uuid or slug) in which the token should be created. This is
-                useful only in cases where the backend used is external, i.e not `wazo_user`.
             hostname:
               type: string
               description: |

--- a/wazo_auth/plugins/http/tokens/api.yml
+++ b/wazo_auth/plugins/http/tokens/api.yml
@@ -19,8 +19,6 @@ paths:
 
         The username/password and refresh_token method of authentication are mutually exclusive
 
-        the hostname and tenant_id must also be mutually exclusive.
-
         For more details about the backends, see http://documentation.wazo.community/en/latest/system/wazo-auth/stock_plugins.html#backends-plugins
       operationId: createToken
       tags:
@@ -42,7 +40,7 @@ paths:
             hostname:
               type: string
               description: |
-                The `hostname/domain_name` used within LDAP authentication. It must be mutually exclusive with the `tenant_id`; raises ValidationError otherwise.
+                The `hostname` must match a tenant's domain_name entry to find the appropriate ldap configuration.
             expiration:
               type: integer
             access_type:

--- a/wazo_auth/plugins/http/tokens/api.yml
+++ b/wazo_auth/plugins/http/tokens/api.yml
@@ -37,10 +37,10 @@ paths:
             backend:
               type: string
               default: wazo_user
-            hostname:
+            domain_name:
               type: string
               description: |
-                The `hostname` must match a tenant's domain_name entry to find the appropriate ldap configuration.
+                The `domain_name` must match a tenant's domain_name entry to find the appropriate ldap configuration.
             expiration:
               type: integer
             access_type:

--- a/wazo_auth/plugins/http/tokens/schemas.py
+++ b/wazo_auth/plugins/http/tokens/schemas.py
@@ -17,7 +17,7 @@ class TokenRequestSchema(BaseSchema):
     client_id = fields.String(validate=Length(min=1, max=1024))
     refresh_token = fields.String()
     tenant_id = fields.String()
-    hostname = fields.String()
+    domain_name = fields.String()
 
     @validates_schema
     def check_access_type_usage(self, data, **kwargs):
@@ -38,21 +38,21 @@ class TokenRequestSchema(BaseSchema):
             )
 
     @validates_schema
-    def check_backend_type_for_tenant_id_and_hostname(self, data, **kwargs):
+    def check_backend_type_for_tenant_id_and_domain_name(self, data, **kwargs):
         backend = data.get('backend')
         if not backend == 'ldap_user':
             return
 
         tenant_id = data.get('tenant_id')
-        hostname = data.get('hostname')
-        if tenant_id and hostname:
+        domain_name = data.get('domain_name')
+        if tenant_id and domain_name:
             raise ValidationError(
-                '"tenant_id" and "hostname" must be mutually exclusive'
+                '"tenant_id" and "domain_name" must be mutually exclusive'
             )
 
-        if not tenant_id and not hostname:
+        if not tenant_id and not domain_name:
             raise ValidationError(
-                '"tenant_id" or "hostname" must be specified when using the "ldap_user" backend'
+                '"tenant_id" or "domain_name" must be specified when using the "ldap_user" backend'
             )
 
     @validates_schema

--- a/wazo_auth/plugins/http/tokens/schemas.py
+++ b/wazo_auth/plugins/http/tokens/schemas.py
@@ -17,6 +17,7 @@ class TokenRequestSchema(BaseSchema):
     client_id = fields.String(validate=Length(min=1, max=1024))
     refresh_token = fields.String()
     tenant_id = fields.String()
+    hostname = fields.String()
 
     @validates_schema
     def check_access_type_usage(self, data, **kwargs):
@@ -37,15 +38,16 @@ class TokenRequestSchema(BaseSchema):
             )
 
     @validates_schema
-    def check_backend_type_for_tenant(self, data, **kwargs):
+    def check_backend_type_for_tenant_id_and_hostname(self, data, **kwargs):
         backend = data.get('backend')
         if not backend == 'ldap_user':
             return
 
         tenant_id = data.get('tenant_id')
-        if not tenant_id:
+        hostname = data.get('hostname')
+        if tenant_id and hostname:
             raise ValidationError(
-                '"tenant_id" must be specified when using ldap backend'
+                '"tenant_id" and "hostname" must be mutually exclusive'
             )
 
     @validates_schema

--- a/wazo_auth/plugins/http/tokens/schemas.py
+++ b/wazo_auth/plugins/http/tokens/schemas.py
@@ -50,6 +50,11 @@ class TokenRequestSchema(BaseSchema):
                 '"tenant_id" and "hostname" must be mutually exclusive'
             )
 
+        if not tenant_id and not hostname:
+            raise ValidationError(
+                '"tenant_id" or "hostname" must be specified when using the "ldap_user" backend'
+            )
+
     @validates_schema
     def check_refresh_token_usage(self, data, **kwargs):
         refresh_token = data.get('refresh_token')

--- a/wazo_auth/plugins/http/tokens/tests/test_schemas.py
+++ b/wazo_auth/plugins/http/tokens/tests/test_schemas.py
@@ -67,15 +67,15 @@ class TestTokenRequestSchema(TestCase):
             raises(ValidationError).matching(has_properties(field_name='_schema')),
         )
 
-    def test_that_ldap_backend_using_both_tenant_id_and_hostname_raises_400(self):
-        body = {'backend': 'ldap_user', 'tenant_id': 'x', 'hostname': 'wazo.io'}
+    def test_that_ldap_backend_using_both_tenant_id_and_domain_name_raises_400(self):
+        body = {'backend': 'ldap_user', 'tenant_id': 'x', 'domain_name': 'wazo.io'}
 
         assert_that(
             calling(self.schema.load).with_args(body),
             raises(ValidationError).matching(has_properties(field_name='_schema')),
         )
 
-    def test_that_ldap_backend_requires_tenant_id_or_hostname(self):
+    def test_that_ldap_backend_requires_tenant_id_or_domain_name(self):
         body = {'backend': 'ldap_user'}
 
         assert_that(
@@ -84,7 +84,7 @@ class TestTokenRequestSchema(TestCase):
         )
 
         assert_that(
-            calling(self.schema.load).with_args({'hostname': 'x', **body}),
+            calling(self.schema.load).with_args({'domain_name': 'x', **body}),
             not_(raises(Exception)),
         )
 

--- a/wazo_auth/plugins/http/tokens/tests/test_schemas.py
+++ b/wazo_auth/plugins/http/tokens/tests/test_schemas.py
@@ -74,3 +74,21 @@ class TestTokenRequestSchema(TestCase):
             calling(self.schema.load).with_args(body),
             raises(ValidationError).matching(has_properties(field_name='_schema')),
         )
+
+    def test_that_ldap_backend_requires_tenant_id_or_hostname(self):
+        body = {'backend': 'ldap_user'}
+
+        assert_that(
+            calling(self.schema.load).with_args({'tenant_id': 'x', **body}),
+            not_(raises(Exception)),
+        )
+
+        assert_that(
+            calling(self.schema.load).with_args({'hostname': 'x', **body}),
+            not_(raises(Exception)),
+        )
+
+        assert_that(
+            calling(self.schema.load).with_args(body),
+            raises(ValidationError).matching(has_properties(field_name='_schema')),
+        )

--- a/wazo_auth/plugins/http/tokens/tests/test_schemas.py
+++ b/wazo_auth/plugins/http/tokens/tests/test_schemas.py
@@ -67,13 +67,8 @@ class TestTokenRequestSchema(TestCase):
             raises(ValidationError).matching(has_properties(field_name='_schema')),
         )
 
-    def test_that_ldap_backend_requires_tenant_id(self):
-        body = {'backend': 'ldap_user'}
-
-        assert_that(
-            calling(self.schema.load).with_args({'tenant_id': 'x', **body}),
-            not_(raises(Exception)),
-        )
+    def test_that_ldap_backend_using_both_tenant_id_and_hostname_raises_400(self):
+        body = {'backend': 'ldap_user', 'tenant_id': 'x', 'hostname': 'wazo.io'}
 
         assert_that(
             calling(self.schema.load).with_args(body),


### PR DESCRIPTION
**Why:**

As a developer, I would like to be able when using LDAP authentication which domain_name I should use:

* it must be mutually exclusive with the slug (400)

* remove tenant_id from the documentation

Depends-On: https://github.com/wazo-platform/wazo-auth-client/pull/31