### PR TITLE
test: use mock from unittest library

### DIFF
--- a/integration_tests/suite/test_db_tenant.py
+++ b/integration_tests/suite/test_db_tenant.py
@@ -3,7 +3,9 @@
 
 import pytest
 
+from unittest.mock import ANY
 from uuid import uuid4
+
 from hamcrest import (
     assert_that,
     calling,
@@ -15,7 +17,6 @@ from hamcrest import (
     has_properties,
     raises,
 )
-from mock import ANY
 
 from wazo_test_helpers.mock import ANY_UUID
 from wazo_auth import exceptions

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -3,6 +3,8 @@
 
 import os
 
+from unittest.mock import ANY
+
 from hamcrest import (
     assert_that,
     calling,
@@ -15,7 +17,6 @@ from hamcrest import (
     none,
     not_,
 )
-from mock import ANY
 from sqlalchemy import and_, func
 
 from wazo_test_helpers.hamcrest.raises import raises

--- a/integration_tests/suite/test_groups.py
+++ b/integration_tests/suite/test_groups.py
@@ -1,7 +1,8 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from functools import partial
+from unittest.mock import ANY
 
 from hamcrest import (
     assert_that,
@@ -12,7 +13,6 @@ from hamcrest import (
     has_items,
     not_,
 )
-from mock import ANY
 from .helpers import base, fixtures
 from .helpers.constants import UNKNOWN_UUID, NB_DEFAULT_GROUPS
 

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -6,9 +6,9 @@ import uuid
 import logging
 
 from datetime import datetime, timedelta
+from unittest.mock import ANY
 
 import requests
-from mock import ANY
 from hamcrest import (
     assert_that,
     calling,

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -1,9 +1,12 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
 import requests
+
 from functools import partial
+from unittest.mock import ANY
+
 from hamcrest import (
     all_of,
     assert_that,
@@ -17,7 +20,6 @@ from hamcrest import (
     none,
     not_,
 )
-from mock import ANY
 from wazo_test_helpers.hamcrest.uuid_ import uuid_
 from .helpers import base
 from .helpers.base import (

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from mock import ANY
+from unittest.mock import ANY
 from hamcrest import (
     assert_that,
     calling,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-mock
 pytest
 pyhamcrest
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -4,8 +4,9 @@
 import unittest
 import ldap
 
+from unittest.mock import call, Mock, patch
+
 from hamcrest import assert_that, equal_to, has_entries, has_items
-from mock import call, Mock, patch
 
 from wazo_auth.plugins.backends.ldap_user import LDAPUser, _WazoLDAP
 
@@ -443,8 +444,8 @@ class TestWazoLDAP(unittest.TestCase):
     def test_wazo_ldap_init_tls(self, ldap_initialize):
         ldapobj = ldap_initialize.return_value = Mock()
 
-        with patch.dict(self.config, {'protocol_security': 'tls'}) as config:
-            wazo_ldap = _WazoLDAP(config)
+        with patch.dict(self.config, {'protocol_security': 'tls'}):
+            wazo_ldap = _WazoLDAP(self.config)
             wazo_ldap.connect()
 
         ldap_initialize.assert_called_once_with(wazo_ldap.uri)

--- a/wazo_auth/plugins/http/tenants/tests/test_tenants.py
+++ b/wazo_auth/plugins/http/tenants/tests/test_tenants.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
+
+from unittest.mock import ANY, Mock, patch, sentinel as s
+
 from hamcrest import assert_that, equal_to, has_entries, has_value, starts_with
-from mock import ANY, Mock, patch, sentinel as s
 from wazo_auth.config import _DEFAULT_CONFIG
 from wazo_auth.tests.test_http import HTTPAppTestCase
 

--- a/wazo_auth/services/tests/test_authentication.py
+++ b/wazo_auth/services/tests/test_authentication.py
@@ -1,10 +1,10 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
+from unittest.mock import sentinel as s, Mock
 
 from hamcrest import assert_that, contains
-from mock import sentinel as s, Mock
 
 from ..authentication import AuthenticationService
 

--- a/wazo_auth/tests/test_helpers.py
+++ b/wazo_auth/tests/test_helpers.py
@@ -1,10 +1,11 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
+from unittest.mock import Mock
+
 from hamcrest import assert_that, equal_to
-from mock import Mock
 
 from ..helpers import LocalTokenRenewer
 

--- a/wazo_auth/tests/test_http.py
+++ b/wazo_auth/tests/test_http.py
@@ -1,12 +1,12 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
+from unittest.mock import ANY, Mock, sentinel as s, patch
 
 from hamcrest import any_of, assert_that, equal_to, has_entries, has_entry
 from flask import Flask
 from flask_restful import Api
-from mock import ANY, Mock, sentinel as s, patch
 
 from xivo import plugin_helpers
 

--- a/wazo_auth/tests/test_purpose.py
+++ b/wazo_auth/tests/test_purpose.py
@@ -1,10 +1,11 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
+from unittest.mock import Mock, sentinel as s
+
 from hamcrest import assert_that, contains, empty, equal_to, not_
-from mock import Mock, sentinel as s
 
 from ..purpose import Purpose, Purposes
 

--- a/wazo_auth/tests/test_services.py
+++ b/wazo_auth/tests/test_services.py
@@ -1,13 +1,13 @@
 # Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, calling, equal_to, has_entries, not_, raises
-from ..schemas import BaseSchema
-from xivo.mallow import fields
-from mock import Mock, patch, sentinel as s
 from unittest import TestCase
+from unittest.mock import Mock, patch, sentinel as s
 
+from hamcrest import assert_that, contains, calling, equal_to, has_entries, not_, raises
 from wazo_auth.config import _DEFAULT_CONFIG
+from xivo.mallow import fields
+
 from .. import exceptions, services
 from ..database import queries
 from ..database.queries import (
@@ -23,6 +23,7 @@ from ..database.queries import (
     token,
     user,
 )
+from ..schemas import BaseSchema
 
 
 class BaseServiceTestCase(TestCase):


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package