### PR TITLE
Pull request for NES-1892-fix-slow-tenants

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     image: wazoplatform/wazo-auth-db:local
     ports:
       - "5432"
+    command: "-c 'log_min_duration_statement=0'"
 
   rabbitmq:
     image: rabbitmq

--- a/integration_tests/suite/test_db_tenant.py
+++ b/integration_tests/suite/test_db_tenant.py
@@ -1,10 +1,12 @@
 # Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import pytest
-
+from contextlib import contextmanager
+from datetime import datetime
 from unittest.mock import ANY
 from uuid import uuid4
+
+import pytest
 
 from hamcrest import (
     assert_that,
@@ -207,6 +209,27 @@ class TestTenantDAO(base.DAOTestCase):
         result = self._tenant_dao.list_(offset=1, order='name', direction='asc')
         expected = build_list_matcher('baz a', 'foo c', 'master')
         assert_that(result, contains(*expected))
+
+    def test_list_benchmark(self):
+        tenant_uuid = self._create_tenant(name='a')
+
+        with self.check_db_requests(nb_requests=1):
+            self._tenant_dao.list_()
+
+        self._tenant_dao.delete(tenant_uuid)
+
+    @contextmanager
+    def check_db_requests(self, nb_requests):
+        time_start = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        nb_logs_start = base.DBAssetLaunchingTestCase.count_database_logs(
+            since=time_start
+        )
+        yield
+        nb_logs_end = base.DBAssetLaunchingTestCase.count_database_logs(
+            since=time_start
+        )
+        nb_db_requests = nb_logs_end - nb_logs_start
+        assert_that(nb_db_requests, equal_to(nb_requests))
 
     @fixtures.db.tenant(name='foobar', domain_names=VALID_DOMAIN_NAMES_1)
     def test_tenant_creation(self, foobar_uuid):

--- a/integration_tests/suite/test_tenants.py
+++ b/integration_tests/suite/test_tenants.py
@@ -321,11 +321,19 @@ class TestTenants(base.APIIntegrationTest):
                 result, has_entries(items=item_matcher, total=total, filtered=filtered)
             )
 
+        foobaz_uuid = foobaz['uuid']
+        foobar['domain_names'] = contains_inanyorder(*foobar['domain_names'])
+        foobaz['domain_names'] = contains_inanyorder(*foobaz['domain_names'])
+        foobarbaz['domain_names'] = contains_inanyorder(*foobarbaz['domain_names'])
+        foobar = has_entries(**foobar)
+        foobaz = has_entries(**foobaz)
+        foobarbaz = has_entries(**foobarbaz)
+
         result = self.client.tenants.list()
         matcher = contains_inanyorder(foobaz, foobar, foobarbaz, top_tenant)
         then(result, item_matcher=matcher)
 
-        result = self.client.tenants.list(uuid=foobaz['uuid'])
+        result = self.client.tenants.list(uuid=foobaz_uuid)
         matcher = contains_inanyorder(foobaz)
         then(result, filtered=1, item_matcher=matcher)
 

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -5,10 +5,10 @@ import random
 import string
 import re
 
-from sqlalchemy import and_, exc, text
+from sqlalchemy import and_, exc, text, func
 from wazo_auth import schemas
 from .base import BaseDAO, PaginatorMixin
-from ..models import Address, Tenant, User
+from ..models import Address, Domain, Tenant, User
 from . import filters
 from ... import exceptions
 
@@ -139,7 +139,7 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         return query.all()
 
     def list_(self, **kwargs):
-        schema = schemas.TenantFullSchema()
+        schema = schemas.TenantRawListSchema()
         filter_ = text('true')
 
         tenant_uuids = kwargs.get('tenant_uuids')
@@ -150,16 +150,23 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         strict_filter = self.new_strict_filter(**kwargs)
         filter_ = and_(filter_, strict_filter, search_filter)
 
+        domain_names = func.array_agg(Domain.name).label('domain_names')
         query = (
-            self.session.query(Tenant, Address)
+            self.session.query(Tenant, Address, domain_names)
             .outerjoin(Address)
+            .outerjoin(Domain)
             .filter(filter_)
             .group_by(Tenant, Address)
         )
         query = self._paginator.update_query(query, **kwargs)
 
-        def to_dict(tenant, address):
+        def to_dict(tenant, address, domain_names):
             tenant.address = address
+            # NOTE(fblackburn): This is an ugly hack to avoid to use setter from Tenant model.
+            # We should avoid to assign attribute to sqlalchemy object in READ operation or we take
+            # risk to update the object in database
+            # NOTE(fblackburn): filter [None] result
+            tenant.raw_domain_names = [name for name in domain_names if name]
             return schema.dump(tenant)
 
         return [to_dict(*row) for row in query.all()]

--- a/wazo_auth/schemas.py
+++ b/wazo_auth/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import post_dump, post_load
@@ -84,6 +84,13 @@ class TenantFullSchema(BaseSchema):
 class TenantPUTSchema(TenantFullSchema):
 
     slug = fields.String(dump_only=True)
+
+
+class TenantRawListSchema(TenantFullSchema):
+
+    domain_names = fields.List(
+        fields.String(), default=[], attribute='raw_domain_names'
+    )
 
 
 class BaseListSchema(mallow.ListSchema):


### PR DESCRIPTION
A best fix would be to only use ORM or only NOT use ORM. Mixing plain sql and ORM is not really friendly...