### PR TITLE
Pull request for default-group-slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   * `policy_uuid`: filter groups that have this policy
   * `policy_slug`: idem with policy slug
 
+* The groups endpoints now accept and return the group attribute `slug`:
+
+  * `GET/POST /groups`
+  * `GET/PUT /groups`
+
 ## 22.09
 
 * The endpoint `GET /users` now accepts the following query string parameters:

--- a/integration_tests/suite/test_groups.py
+++ b/integration_tests/suite/test_groups.py
@@ -289,15 +289,15 @@ class TestGroups(base.APIIntegrationTest):
                 total=NB_DEFAULT_GROUPS,
                 filtered=NB_DEFAULT_GROUPS,
                 items=contains_inanyorder(
-                    has_entries(name=f'wazo-all-users-tenant-{self.top_tenant_uuid}'),
-                    has_entries(name='wazo_default_admin_group'),
+                    has_entries(slug=f'wazo-all-users-tenant-{self.top_tenant_uuid}'),
+                    has_entries(slug='wazo_default_admin_group'),
                 ),
             ),
         )
 
         # assert policies in master tenant
         admin_group_uuid = self.client.groups.list(
-            tenant_uuid=self.top_tenant_uuid, name='wazo_default_admin_group'
+            tenant_uuid=self.top_tenant_uuid, slug='wazo_default_admin_group'
         )['items'][0]['uuid']
         response = self.client.groups.get_policies(
             admin_group_uuid, tenant_uuid=self.top_tenant_uuid
@@ -305,7 +305,7 @@ class TestGroups(base.APIIntegrationTest):
         assert_that(
             response,
             has_entries(
-                items=contains_inanyorder(has_entries(name='wazo_default_admin_policy'))
+                items=contains_inanyorder(has_entries(slug='wazo_default_admin_policy'))
             ),
         )
 
@@ -317,14 +317,14 @@ class TestGroups(base.APIIntegrationTest):
                 total=NB_DEFAULT_GROUPS,
                 filtered=NB_DEFAULT_GROUPS,
                 items=contains_inanyorder(
-                    has_entries(name=f'wazo-all-users-tenant-{base.SUB_TENANT_UUID}'),
-                    has_entries(name='wazo_default_admin_group'),
+                    has_entries(slug=f'wazo-all-users-tenant-{base.SUB_TENANT_UUID}'),
+                    has_entries(slug='wazo_default_admin_group'),
                 ),
             ),
         )
         # assert policies in subtenant
         admin_group_uuid = self.client.groups.list(
-            tenant_uuid=base.SUB_TENANT_UUID, name='wazo_default_admin_group'
+            tenant_uuid=base.SUB_TENANT_UUID, slug='wazo_default_admin_group'
         )['items'][0]['uuid']
         response = self.client.groups.get_policies(
             admin_group_uuid, tenant_uuid=base.SUB_TENANT_UUID
@@ -332,7 +332,7 @@ class TestGroups(base.APIIntegrationTest):
         assert_that(
             response,
             has_entries(
-                items=contains_inanyorder(has_entries(name='wazo_default_admin_policy'))
+                items=contains_inanyorder(has_entries(slug='wazo_default_admin_policy'))
             ),
         )
 

--- a/integration_tests/suite/test_groups.py
+++ b/integration_tests/suite/test_groups.py
@@ -336,22 +336,26 @@ class TestGroups(base.APIIntegrationTest):
             ),
         )
 
-        # assert policies after restart in subtenant
-        # remove all policies
+    @fixtures.http.tenant(uuid=base.SUB_TENANT_UUID)
+    def test_default_groups_policies_are_restored_after_restart(self, _):
+        admin_group_uuid = self.client.groups.list(
+            tenant_uuid=base.SUB_TENANT_UUID, slug='wazo_default_admin_group'
+        )['items'][0]['uuid']
+
         group_policies = self.client.groups.get_policies(
             admin_group_uuid, tenant_uuid=base.SUB_TENANT_UUID
         )['items']
         for group_policy in group_policies:
             self.client.groups.remove_policy(admin_group_uuid, group_policy['uuid'])
-        # restart
+
         self.restart_auth()
-        # check policies are still present
+
         response = self.client.groups.get_policies(
             admin_group_uuid, tenant_uuid=base.SUB_TENANT_UUID
         )
         assert_that(
             response,
             has_entries(
-                items=contains_inanyorder(has_entries(name='wazo_default_admin_policy'))
+                items=contains_inanyorder(has_entries(slug='wazo_default_admin_policy'))
             ),
         )

--- a/wazo_auth/plugins/http/groups/api.yml
+++ b/wazo_auth/plugins/http/groups/api.yml
@@ -247,9 +247,3 @@ definitions:
         description: '*Deprecated* Please use `read_only`'
       read_only:
         type: boolean
-    required:
-    - uuid
-    - name
-    - slug
-    - read_only
-    - tenant_uuid

--- a/wazo_auth/plugins/http/groups/api.yml
+++ b/wazo_auth/plugins/http/groups/api.yml
@@ -219,6 +219,8 @@ definitions:
     properties:
       name:
         type: string
+      slug:
+        type: string
     required:
       - name
   GroupResult:
@@ -227,6 +229,8 @@ definitions:
       uuid:
         type: string
       name:
+        type: string
+      slug:
         type: string
       tenant_uuid:
         type: string
@@ -238,5 +242,6 @@ definitions:
     required:
     - uuid
     - name
+    - slug
     - read_only
     - tenant_uuid

--- a/wazo_auth/plugins/http/groups/api.yml
+++ b/wazo_auth/plugins/http/groups/api.yml
@@ -140,7 +140,7 @@ paths:
         description: The group parameters
         required: true
         schema:
-          $ref: '#/definitions/Group'
+          $ref: '#/definitions/GroupPut'
       responses:
         '200':
           description: "The modified group's data"
@@ -220,6 +220,14 @@ definitions:
       name:
         type: string
       slug:
+        type: string
+        default: <name>
+    required:
+      - name
+  GroupPut:
+    type: object
+    properties:
+      name:
         type: string
     required:
       - name

--- a/wazo_auth/services/default_group.py
+++ b/wazo_auth/services/default_group.py
@@ -26,7 +26,7 @@ class DefaultGroupService:
 
     def update_groups_for_tenant(self, tenant_uuid):
         for group_slug, group_args in self._default_groups.items():
-            group = self._dao.group.find_by(name=group_slug, tenant_uuid=tenant_uuid)
+            group = self._dao.group.find_by(slug=group_slug, tenant_uuid=tenant_uuid)
             if group:
                 self._update_group(tenant_uuid, group.uuid, group_slug, group_args)
             else:


### PR DESCRIPTION
## default groups: use slug to detect existing groups

Why:

* the name can be arbitrarily changed and is less reliable than the slug

## test groups: split test too long


## groups: add slug to api spec