### PR TITLE
allow to change user password when only email is defined

### DIFF
--- a/integration_tests/suite/test_password_reset.py
+++ b/integration_tests/suite/test_password_reset.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime
@@ -70,7 +70,7 @@ class TestResetPassword(base.APIIntegrationTest):
         # non-regression: bootstrap user still have password
         assert_no_error(self.client.token.new, 'wazo_user', expiration=1)
 
-    @fixtures.http.user()
+    @fixtures.http.user(username='foobar')
     def test_set_password_does_not_log_password(self, user):
         new_password = '5ecr37'
 

--- a/integration_tests/suite/test_users.py
+++ b/integration_tests/suite/test_users.py
@@ -447,6 +447,18 @@ class TestUsers(base.APIIntegrationTest):
         assert_that(logs, not_(contains_string(old_password)))
         assert_that(logs, not_(contains_string(new_password)))
 
+    @fixtures.http.user(username=None, email_address='u1@example.com', password='pass1')
+    @fixtures.http.user(username=None, email_address='u2@example.com', password='pass2')
+    def test_put_password_when_many_username_to_none(self, user1, user2):
+        old_password = 'pass1'
+        new_password = 'new-pass1'
+        assert_no_error(
+            self.client.users.change_password,
+            user1['uuid'],
+            old_password=old_password,
+            new_password=new_password,
+        )
+
     def test_list(self):
         with self.client_in_subtenant(username='foo') as (top_client, _, top):
             with self.client_in_subtenant(username='bar', parent_uuid=top['uuid']) as (

--- a/wazo_auth/services/user.py
+++ b/wazo_auth/services/user.py
@@ -33,7 +33,15 @@ class UserService(BaseService):
 
     def change_password(self, user_uuid, old_password, new_password, reset=False):
         user = self.get_user(user_uuid)
-        if not self.verify_password(user['username'], old_password, reset):
+        login = user['username']
+        if not login:
+            try:
+                login = user['emails'][0]['address']
+            except IndexError:
+                logger.warning('User %s does not have login (username or email)')
+                raise exceptions.AuthenticationFailedException()
+
+        if not self.verify_password(login, old_password, reset):
             raise exceptions.AuthenticationFailedException()
 
         salt, hash_ = self._encrypter.encrypt_password(new_password)


### PR DESCRIPTION
why: When using email as login, the username can be none. So we must
handled this case too. Otherwise the first user with username=None will
be taken