### PR TITLE
LDAP authentification is case sensitive

### DIFF
--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -220,6 +220,34 @@ class TestLDAP(BaseLDAPIntegrationTest):
     @fixtures.http.tenant(
         uuid=TENANT_1_UUID,
         slug='mytenant',
+    )
+    @fixtures.http.user(
+        email_address='AWONDERLAND@WAZO-AUTH.COM', tenant_uuid=TENANT_1_UUID
+    )
+    @fixtures.http.ldap_config(
+        tenant_uuid=TENANT_1_UUID,
+        host='slapd',
+        port=LDAP_PORT,
+        user_base_dn='ou=quebec,ou=people,dc=wazo-auth,dc=wazo,dc=community',
+        user_login_attribute='cn',
+        user_email_attribute='mail',
+    )
+    def test_ldap_authentication_works_when_case_sensitive_user_email(
+        self, tenant, user, _
+    ):
+        response = self._post_token(
+            'Alice Wonderland',
+            'awonderland_password',
+            backend='ldap_user',
+            tenant_id=tenant['uuid'],
+        )
+        assert_that(
+            response, has_entries(metadata=has_entries(pbx_user_uuid=user['uuid']))
+        )
+
+    @fixtures.http.tenant(
+        uuid=TENANT_1_UUID,
+        slug='mytenant',
         domain_names=['wazo.community', 'cust-42.myclients.com'],
     )
     @fixtures.http.user(

--- a/wazo_auth/plugins/http/users/schemas.py
+++ b/wazo_auth/plugins/http/users/schemas.py
@@ -4,6 +4,7 @@
 from xivo.mallow import fields
 from xivo.mallow import validate
 from wazo_auth.schemas import BaseSchema
+from marshmallow import post_load
 
 
 class _BaseUserSchema(BaseSchema):
@@ -24,6 +25,13 @@ class UserPostSchema(_BaseUserSchema):
     uuid = fields.UUID()
     password = fields.String(validate=validate.Length(min=1), allow_none=True)
     email_address = fields.Email(allow_none=True)
+
+    @post_load
+    def _ensure_email_address_is_lower_case(self, data, **kwargs):
+        if 'email_address' in data.keys():
+            if data['email_address']:
+                data['email_address'] = data['email_address'].lower()
+        return data
 
 
 class UserPutSchema(_BaseUserSchema):


### PR DESCRIPTION
**Problem:**
* When we have a user comfigured within ldap configuration with the following email `awonderland@wazo-auth.com`, and this user tries to login with the same email address but containing upper case letters instead; like: `AWONDERLAND@WAZO-AUTH.COM` then it raises an HTTP 401 error code.

**Expected Behaviour:**
* We should accept any email address as long as they are the same when lowered.