### PR TITLE
LDAP authentication is case-sensitive

### DIFF
--- a/integration_tests/suite/test_backend_ldap.py
+++ b/integration_tests/suite/test_backend_ldap.py
@@ -231,34 +231,6 @@ class TestLDAP(BaseLDAPIntegrationTest):
         slug='mytenant',
     )
     @fixtures.http.user(
-        email_address='JSparrow@wazo-auth.com', tenant_uuid=TENANT_1_UUID
-    )
-    @fixtures.http.ldap_config(
-        tenant_uuid=TENANT_1_UUID,
-        host='slapd',
-        port=LDAP_PORT,
-        user_base_dn='ou=quebec,ou=people,dc=wazo-auth,dc=wazo,dc=community',
-        user_login_attribute='cn',
-        user_email_attribute='mail',
-    )
-    def test_ldap_authentication_works_when_case_sensitive_wazo_auth_user_email(
-        self, tenant, user, _
-    ):
-        response = self._post_token(
-            'Jack Sparrow',
-            'jsparrow_password',
-            backend='ldap_user',
-            tenant_id=tenant['uuid'],
-        )
-        assert_that(
-            response, has_entries(metadata=has_entries(pbx_user_uuid=user['uuid']))
-        )
-
-    @fixtures.http.tenant(
-        uuid=TENANT_1_UUID,
-        slug='mytenant',
-    )
-    @fixtures.http.user(
         email_address='jsparrow@wazo-auth.com', tenant_uuid=TENANT_1_UUID
     )
     @fixtures.http.ldap_config(

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -1,7 +1,7 @@
 # Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy import and_, or_, exc, func, text
+from sqlalchemy import and_, or_, exc, text
 from sqlalchemy.orm import joinedload
 from .base import BaseDAO, PaginatorMixin
 from . import filters
@@ -241,7 +241,7 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             .outerjoin(Email)
             .filter(
                 and_(
-                    func.lower(Email.address) == func.lower(login),
+                    Email.address == login,
                     Email.confirmed.is_(True),
                 )
             )

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -1,7 +1,7 @@
 # Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy import and_, or_, exc, text
+from sqlalchemy import and_, or_, exc, func, text
 from sqlalchemy.orm import joinedload
 from .base import BaseDAO, PaginatorMixin
 from . import filters
@@ -239,7 +239,12 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         query = (
             self.session.query(User.uuid)
             .outerjoin(Email)
-            .filter(and_(Email.address == login, Email.confirmed.is_(True)))
+            .filter(
+                and_(
+                    func.lower(Email.address) == func.lower(login),
+                    Email.confirmed.is_(True),
+                )
+            )
         )
         row = query.first()
         if row:

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -147,10 +147,10 @@ class LDAPUser(BaseAuthenticationBackend):
 
     def _get_user_by_ldap_attribute(self, user_email, tenant_uuid):
         for user in self._user_service.list_users(tenant_uuid=tenant_uuid):
-            if 'emails' in user.keys() and user['emails']:
-                wazo_auth_user_email = user['emails'][0]['address']
-                if wazo_auth_user_email.lower() == user_email.lower():
-                    return user
+            if user.get('emails'):
+                for email in user.get('emails'):
+                    if email['address'] == user_email.lower():
+                        return user
         logger.warning(
             '%s does not have an email associated with an auth user', user_email
         )

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -147,11 +147,10 @@ class LDAPUser(BaseAuthenticationBackend):
 
     def _get_user_by_ldap_attribute(self, user_email, tenant_uuid):
         for user in self._user_service.list_users(tenant_uuid=tenant_uuid):
-            if 'emails' in user.keys():
-                if user['emails']:
-                    wazo_auth_user_email = user['emails'][0]['address']
-                    if wazo_auth_user_email.lower() == user_email.lower():
-                        return user
+            if 'emails' in user.keys() and user['emails']:
+                wazo_auth_user_email = user['emails'][0]['address']
+                if wazo_auth_user_email.lower() == user_email.lower():
+                    return user
         logger.warning(
             '%s does not have an email associated with an auth user', user_email
         )

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -147,9 +147,10 @@ class LDAPUser(BaseAuthenticationBackend):
 
     def _get_user_by_ldap_attribute(self, user_email, tenant_uuid):
         for user in self._user_service.list_users(tenant_uuid=tenant_uuid):
-            if user.get('emails'):
-                for email in user.get('emails'):
-                    if email['address'] == user_email.lower():
+            user_emails = user.get('emails')
+            if user_emails:
+                for email in user_emails:
+                    if email['address'] == user_email:
                         return user
         logger.warning(
             '%s does not have an email associated with an auth user', user_email
@@ -172,7 +173,7 @@ class LDAPUser(BaseAuthenticationBackend):
     def _extract_email_attribute(self, ldap_obj, user_email_attribute):
         email = ldap_obj.get(user_email_attribute, None)
         email = email[0] if isinstance(email, list) else email
-        return email.decode('utf-8') if email else None
+        return email.decode('utf-8').lower() if email else None
 
     def _perform_search_attributes(
         self,

--- a/wazo_auth/plugins/backends/ldap_user.py
+++ b/wazo_auth/plugins/backends/ldap_user.py
@@ -146,11 +146,12 @@ class LDAPUser(BaseAuthenticationBackend):
         return self._tenant_service.get_by_uuid_or_slug(None, tenant_id)
 
     def _get_user_by_ldap_attribute(self, user_email, tenant_uuid):
-        for user in self._user_service.list_users(
-            email_address=user_email, tenant_uuid=tenant_uuid
-        ):
-            return user
-
+        for user in self._user_service.list_users(tenant_uuid=tenant_uuid):
+            if 'emails' in user.keys():
+                if user['emails']:
+                    wazo_auth_user_email = user['emails'][0]['address']
+                    if wazo_auth_user_email.lower() == user_email.lower():
+                        return user
         logger.warning(
             '%s does not have an email associated with an auth user', user_email
         )

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -212,17 +212,20 @@ class TestVerifyPassword(BaseTestCase):
 
         wazo_ldap = wazo_ldap.return_value
         wazo_ldap.perform_bind.return_value = True
-        wazo_ldap.perform_search.return_value = self.search_obj_result
+        wazo_ldap.perform_search.return_value = (
+            'uid=fo\\+o,dc=example,dc=com',
+            {'mail': self.expected_user_email.encode('utf-8')},
+        )
         self.list_users.return_value = [
             {'uuid': 'alice-uuid', 'emails': [{'address': 'foo@example.com'}]}
         ]
         args = {'tenant_id': 'test'}
 
-        result = backend.verify_password('foo', 'bar', args)
+        result = backend.verify_password('fo+o', 'bar', args)
 
         assert_that(result, equal_to(True))
         wazo_ldap.perform_bind.assert_called_once_with(
-            'uid=foo,dc=example,dc=com', 'bar'
+            'uid=fo\\+o,dc=example,dc=com', 'bar'
         )
 
     def test_that_verify_password_escape_filter_chars(self, wazo_ldap):
@@ -239,17 +242,20 @@ class TestVerifyPassword(BaseTestCase):
 
         wazo_ldap = wazo_ldap.return_value
         wazo_ldap.perform_bind.return_value = True
-        wazo_ldap.perform_search.return_value = self.search_obj_result
+        wazo_ldap.perform_search.return_value = (
+            'uid=fo\\+o,dc=example,dc=com',
+            {'mail': self.expected_user_email.encode('utf-8')},
+        )
         self.list_users.return_value = [
             {'uuid': 'alice-uuid', 'emails': [{'address': 'foo@example.com'}]}
         ]
         args = {'tenant_id': 'test'}
 
-        result = backend.verify_password('foo', 'bar', args)
+        result = backend.verify_password('fo+o', 'bar', args)
 
         assert_that(result, equal_to(True))
         wazo_ldap.perform_search.assert_called_once_with(
-            'uid=foo,dc=example,dc=com', 0, attrlist=['mail']
+            'uid=fo\\+o,dc=example,dc=com', 0, attrlist=['mail']
         )
 
     def test_that_verify_password_calls_return_false_when_no_user_bind(self, wazo_ldap):

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -188,7 +188,9 @@ class TestVerifyPassword(BaseTestCase):
         wazo_ldap = wazo_ldap.return_value
         wazo_ldap.perform_bind.return_value = True
         wazo_ldap.perform_search.return_value = self.search_obj_result
-        self.list_users.return_value = [{'uuid': 'alice-uuid'}]
+        self.list_users.return_value = [
+            {'uuid': 'alice-uuid', 'emails': [{'address': 'foo@example.com'}]}
+        ]
         args = {'tenant_id': 'test'}
 
         result = backend.verify_password('foo', 'bar', args)
@@ -210,15 +212,17 @@ class TestVerifyPassword(BaseTestCase):
 
         wazo_ldap = wazo_ldap.return_value
         wazo_ldap.perform_bind.return_value = True
-        wazo_ldap.perform_search.return_value = ('uid=fo\\+o,dc=example,dc=com', Mock())
-        self.list_users.return_value = [{'uuid': 'alice-uuid'}]
+        wazo_ldap.perform_search.return_value = self.search_obj_result
+        self.list_users.return_value = [
+            {'uuid': 'alice-uuid', 'emails': [{'address': 'foo@example.com'}]}
+        ]
         args = {'tenant_id': 'test'}
 
-        result = backend.verify_password('fo+o', 'bar', args)
+        result = backend.verify_password('foo', 'bar', args)
 
         assert_that(result, equal_to(True))
         wazo_ldap.perform_bind.assert_called_once_with(
-            'uid=fo\\+o,dc=example,dc=com', 'bar'
+            'uid=foo,dc=example,dc=com', 'bar'
         )
 
     def test_that_verify_password_escape_filter_chars(self, wazo_ldap):
@@ -235,15 +239,17 @@ class TestVerifyPassword(BaseTestCase):
 
         wazo_ldap = wazo_ldap.return_value
         wazo_ldap.perform_bind.return_value = True
-        wazo_ldap.perform_search.return_value = ('uid=fo\\+o,dc=example,dc=com', Mock())
-        self.list_users.return_value = [{'uuid': 'alice-uuid'}]
+        wazo_ldap.perform_search.return_value = self.search_obj_result
+        self.list_users.return_value = [
+            {'uuid': 'alice-uuid', 'emails': [{'address': 'foo@example.com'}]}
+        ]
         args = {'tenant_id': 'test'}
 
-        result = backend.verify_password('fo+o', 'bar', args)
+        result = backend.verify_password('foo', 'bar', args)
 
         assert_that(result, equal_to(True))
         wazo_ldap.perform_search.assert_called_once_with(
-            'uid=fo\\+o,dc=example,dc=com', 0, attrlist=['mail']
+            'uid=foo,dc=example,dc=com', 0, attrlist=['mail']
         )
 
     def test_that_verify_password_calls_return_false_when_no_user_bind(self, wazo_ldap):
@@ -307,7 +313,9 @@ class TestVerifyPassword(BaseTestCase):
         wazo_ldap = wazo_ldap.return_value
         wazo_ldap.perform_bind.return_value = True
         wazo_ldap.perform_search.return_value = self.search_obj_result
-        self.list_users.return_value = [{'uuid': 'alice-uuid'}]
+        self.list_users.return_value = [
+            {'uuid': 'alice-uuid', 'emails': [{'address': 'foo@example.com'}]}
+        ]
         args = {'tenant_id': 'test'}
 
         result = backend.verify_password('foo', 'bar', args)
@@ -349,7 +357,9 @@ class TestVerifyPassword(BaseTestCase):
         wazo_ldap = wazo_ldap.return_value
         wazo_ldap.perform_bind.return_value = True
         wazo_ldap.perform_search.return_value = self.search_obj_result
-        self.list_users.return_value = [{'uuid': 'alice-uuid'}]
+        self.list_users.return_value = [
+            {'uuid': 'alice-uuid', 'emails': [{'address': 'foo@example.com'}]}
+        ]
         args = {'tenant_id': 'test'}
 
         result = backend.verify_password('foo', 'bar', args)
@@ -383,7 +393,9 @@ class TestVerifyPassword(BaseTestCase):
         wazo_ldap = wazo_ldap.return_value
         wazo_ldap.perform_bind.return_value = True
         wazo_ldap.perform_search.return_value = self.search_obj_result
-        self.list_users.return_value = [{'uuid': 'alice-uuid'}]
+        self.list_users.return_value = [
+            {'uuid': 'alice-uuid', 'emails': [{'address': 'foo@example.com'}]}
+        ]
         args = {'domain_name': 'wazo.io'}
 
         result = backend.verify_password('foo', 'bar', args)

--- a/wazo_auth/plugins/backends/tests/test_ldap_user.py
+++ b/wazo_auth/plugins/backends/tests/test_ldap_user.py
@@ -402,6 +402,32 @@ class TestVerifyPassword(BaseTestCase):
 
         assert_that(result, equal_to(True))
 
+    def test_that_verify_password_works_using_case_sensitive_email_address(
+        self, wazo_ldap
+    ):
+        backend = LDAPUser()
+        backend.load(
+            {
+                'user_service': self.user_service,
+                'group_service': self.group_service,
+                'ldap_service': self.ldap_service,
+                'tenant_service': self.tenant_service,
+                'purposes': self.purposes,
+            }
+        )
+
+        wazo_ldap = wazo_ldap.return_value
+        wazo_ldap.perform_bind.return_value = True
+        wazo_ldap.perform_search.return_value = self.search_obj_result
+        self.list_users.return_value = [
+            {'uuid': 'alice-uuid', 'emails': [{'address': 'foo@example.com'}]}
+        ]
+        args = {'domain_name': 'wazo.io'}
+
+        result = backend.verify_password('FoO@EXampLE.coM', 'bar', args)
+
+        assert_that(result, equal_to(True))
+
     def test_that_verify_password_using_non_existing_domain_name_returns_false(
         self, wazo_ldap
     ):


### PR DESCRIPTION
**Problem:**
* When we have a user comfigured within ldap configuration with the following email `awonderland@wazo-auth.com`, and this user tries to login with the same email address but containing upper case letters instead; like: `AWONDERLAND@WAZO-AUTH.COM` then it raises an HTTP 401 error code.

**Expected Behaviour:**
* We should accept any email address as long as they are the same when lowered; but we should not change/modify the current configuration or user creation process