### PR TITLE
[WP-688] Update link provided in reset password template

### DIFF
--- a/templates/password_reset_email.jinja
+++ b/templates/password_reset_email.jinja
@@ -6,6 +6,6 @@ If you did not ask to reset your password, please ignore this email.
 
 To reset your password, click on the following link:
 
-https://app.wazo.io/?host={{ hostname }}{% if port %}:{{ port }}{% endif %}&token={{ token }}&user_uuid={{ user_uuid }}#reset-password
+https://app.wazo.io/reset-password?host={{ hostname }}{% if port %}:{{ port }}{% endif %}&token={{ token }}&user_uuid={{ user_uuid }}
 
 The Wazo team wishes you a great day.


### PR DESCRIPTION
## Summary of changes
- Provide a URL respecting the `https://app.wazo.io/reset-password?host=xxx&token=xxx&user_uuid=xxx` format

## Note
Should only be merged once infrastructure supports that URL format (see `IN-45`)