### PR TITLE
disable consul/service_discovery by default

### DIFF
--- a/debian/wazo-auth.links
+++ b/debian/wazo-auth.links
@@ -1,2 +1,0 @@
-/var/lib/consul/default_xivo_consul_config.yml /etc/wazo-auth/conf.d/050-xivo-consul-config.yml
-/var/lib/consul/default_xivo_consul_token.yml /etc/wazo-auth/conf.d/050-xivo-consul-token.yml

--- a/etc/wazo-auth/config.yml
+++ b/etc/wazo-auth/config.yml
@@ -80,34 +80,40 @@ smtp:
   hostname: localhost
   port: 25
 
-consul:
-  scheme: http
-  host: localhost
-  port: 8500
-  token: 'the_one_ring'
-
 # Database connection settings.
 db_uri: postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-auth
 confd_db_uri: postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-auth
 
-# Service discovery configuration. all time intervals are in seconds
 service_discovery:
-  # Indicates whether of not to use service discovery.
-  # It should only be disabled for testing purposes.
-  enabled: true
-  # The address that will be received by other services using service discovery.
-  # Use "advertise_address: auto" to enable ip address detection based on
-  # advertise_address_interface
-  advertise_address: auto
-  # If advertise_address is "auto" this interface will be used to find the ip
-  # address to advertise. Ignored otherwise
-  advertise_address_interface: eth0
-  advertise_port: 9497
-  # The number of seconds that consul will wait between 2 ttl messages to mark
-  # this service as up
-  ttl_interval: 30
-  # The time interval before the service sends a new ttl message to consul
-  refresh_interval: 27
-  # The time interval to detect that the service is running when starting
-  retry_interval: 2
-  extra_tags: []
+  enabled: false
+
+# Example of service discovery settings
+#
+# Necessary to use service discovery
+# consul:
+#   scheme: http
+#   host: localhost
+#   port: 8500
+#   token: 'the_one_ring'
+#
+# # All time intervals are in seconds
+# service_discovery:
+#   # Indicates whether of not to use service discovery.
+#   enabled: true
+#   # The address that will be received by other services using service discovery.
+#   # Use "advertise_address: auto" to enable ip address detection based on
+#   # advertise_address_interface
+#   advertise_address: auto
+#   # If advertise_address is "auto" this interface will be used to find the ip
+#   # address to advertise. Ignored otherwise
+#   advertise_address_interface: eth0
+#   advertise_port: 9497
+#   # The number of seconds that consul will wait between 2 ttl messages to mark
+#   # this service as up
+#   ttl_interval: 30
+#   # The time interval before the service sends a new ttl message to consul
+#   refresh_interval: 27
+#   # The time interval to detect that the service is running when starting
+#   retry_interval: 2
+#   extra_tags: []
+

--- a/etc/wazo-auth/config.yml
+++ b/etc/wazo-auth/config.yml
@@ -87,12 +87,12 @@ confd_db_uri: postgresql://asterisk:proformatique@localhost/asterisk?application
 service_discovery:
   enabled: false
 
-# Example of service discovery settings
+# Example settings to enable service discovery
 #
 # Necessary to use service discovery
 # consul:
 #   scheme: http
-#   host: localhost
+#   host: consul.example.com
 #   port: 8500
 #   token: 'the_one_ring'
 #

--- a/integration_tests/assets/etc/wazo-auth/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/50-default.yml
@@ -11,9 +11,6 @@ amqp:
 smtp:
   hostname: smtp
 
-service_discovery:
-  enabled: false
-
 enabled_http_plugins:
   user_registration: true
 

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -90,12 +90,15 @@ _DEFAULT_CONFIG = {
             ],
         },
     },
-    'consul': {'scheme': 'http', 'host': 'localhost', 'port': 8500},
+    'consul': {
+        'scheme': 'http',
+        'port': 8500,
+    },
     'service_discovery': {
+        'enabled': False,
         'advertise_address': 'auto',
         'advertise_address_interface': 'eth0',
         'advertise_port': _DEFAULT_HTTP_PORT,
-        'enabled': True,
         'ttl_interval': 30,
         'refresh_interval': 27,
         'retry_interval': 2,


### PR DESCRIPTION
why: consul is not used in default install
- Remove host key from default consul setting to block service start if
  not defined
- Keep common service_discovery and consul key in config.py to avoid
  to redefine everything when using these settings