### PR TITLE
WAZO-2943: fix acl on list_connected_users for external endpoint

### DIFF
--- a/wazo_auth/plugins/http/external/http.py
+++ b/wazo_auth/plugins/http/external/http.py
@@ -73,7 +73,7 @@ class ExternalUsers(http.AuthResource):
     def __init__(self, external_auth_service):
         self.service = external_auth_service
 
-    @http.required_acl('auth.{auth_type}.external.users')
+    @http.required_acl('auth.{auth_type}.external.users.read')
     def get(self, auth_type):
         try:
             list_params = schemas.BaseListSchema().load(request.args)


### PR DESCRIPTION
* added the .read to be more consistent with style