### PR TITLE
adapt tox.ini for tox4

### DIFF
--- a/integration_tests/suite/test_ldap_config.py
+++ b/integration_tests/suite/test_ldap_config.py
@@ -7,7 +7,7 @@ from hamcrest import (
     has_key,
     not_,
 )
-from integration_tests.suite.helpers.constants import UNKNOWN_TENANT
+from .helpers.constants import UNKNOWN_TENANT
 
 from .helpers import base
 from .helpers import fixtures

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist = py37, linters
-skipsdist = true
+skipsdist = false
 
 [testenv]
 basepython = python3.7
@@ -32,7 +32,7 @@ commands =
     flake8
 
 [testenv:integration]
-usedevelop = true
+use_develop = true
 deps = -rintegration_tests/test-requirements-for-tox.txt
 changedir = integration_tests
 passenv =
@@ -43,7 +43,7 @@ passenv =
 commands =
     make test-setup
     pytest {posargs}
-whitelist_externals =
+allowlist_externals =
     make
 
 [flake8]


### PR DESCRIPTION
Why:

* skipsdist and usedevelop are now mutually exclusive
* usedevelop -> use_develop for future
* whitelist_externals -> allowlist_externals