### PR TITLE
WAZO-3009: dont check for sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 23.01
+
+* `GET /external/{auth_type}/users`: no longer discards user without an active session with the stack, all users with a token with the service will be returned
+
 ## 22.17
 
 * Added a new endpoint to retrieve the list of connected users registered with the specified auth type

--- a/integration_tests/suite/test_db_external_auth.py
+++ b/integration_tests/suite/test_db_external_auth.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -70,8 +70,6 @@ class TestExternalAuthDAO(base.DAOTestCase):
 
     @fixtures.db.user(uuid=USER_UUID_1)
     @fixtures.db.user(uuid=USER_UUID_2)
-    @fixtures.db.token(auth_id=USER_UUID_1)
-    @fixtures.db.token(auth_id=USER_UUID_2)
     @fixtures.db.external_auth('foobarcrm')
     def test_count_connected_users(self, user1_uuid, user2_uuid, *_):
         self._external_auth_dao.create(user1_uuid, 'foobarcrm', 'some-data')
@@ -287,8 +285,6 @@ class TestExternalAuthDAO(base.DAOTestCase):
     @fixtures.db.user(uuid=USER_UUID_2)
     @fixtures.db.user()
     @fixtures.db.external_auth('foobarcrm')
-    @fixtures.db.token(auth_id=USER_UUID_1)
-    @fixtures.db.token(auth_id=USER_UUID_2)
     def test_list_connected_users(self, user1_uuid, user2_uuid, user3_uuid, *ignored):
         self._external_auth_dao.create(user1_uuid, 'foobarcrm', {})
 
@@ -303,7 +299,12 @@ class TestExternalAuthDAO(base.DAOTestCase):
 
         self._external_auth_dao.create(user3_uuid, 'foobarcrm', {})
         results = self._external_auth_dao.list_connected_users('foobarcrm')
-        expected = [user1_uuid, user2_uuid]
+        expected = [user1_uuid, user2_uuid, user3_uuid]
+        assert_that(results, contains_inanyorder(*expected))
+
+        self._external_auth_dao.delete(user2_uuid, 'foobarcrm')
+        results = self._external_auth_dao.list_connected_users('foobarcrm')
+        expected = [user1_uuid, user3_uuid]
         assert_that(results, contains_inanyorder(*expected))
 
         results = self._external_auth_dao.list_connected_users('foobarcrm', limit=1)

--- a/wazo_auth/database/queries/external_auth.py
+++ b/wazo_auth/database/queries/external_auth.py
@@ -1,16 +1,14 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
-from sqlalchemy import and_, exc, select, join, alias
+from sqlalchemy import and_, exc
 from .base import BaseDAO, PaginatorMixin
 from . import filters
 from ..models import (
     ExternalAuthConfig,
     ExternalAuthType,
-    Session,
     Tenant,
-    Token,
     User,
     UserExternalAuth,
 )
@@ -248,20 +246,11 @@ class ExternalAuthDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         if tenant_uuids is not None:
             filter_ = and_(filter_, User.tenant_uuid.in_(tenant_uuids))
 
-        # Subquery to find users session
-        sessions_query = alias(
-            select([Token.auth_id]).select_from(join(Token, Session))
-        )
-
         query = (
             self.session.query(UserExternalAuth.user_uuid)
             .outerjoin(ExternalAuthType)
             .outerjoin(User)
-            .join(
-                sessions_query, sessions_query.c.auth_id == UserExternalAuth.user_uuid
-            )
             .filter(filter_)
-            .distinct()
         )
 
         return query


### PR DESCRIPTION
Because user without a session (e.g: plastic phone only) still want to be picked up by this API, we only check if the user has a token with the service