### PR TITLE
db: make all connections persistent

### DIFF
--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -38,7 +38,7 @@ def _check_required_config_for_other_threads(config):
 
 class Controller:
     def __init__(self, config):
-        init_db(config['db_uri'], max_connections=config['rest_api']['max_threads'])
+        init_db(config['db_uri'], pool_size=config['rest_api']['max_threads'])
         self._config = config
         self._stopping_thread = None
         _check_required_config_for_other_threads(config)

--- a/wazo_auth/database/helpers.py
+++ b/wazo_auth/database/helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -14,13 +14,9 @@ logger = logging.getLogger(__name__)
 
 Session = scoped_session(sessionmaker())
 
-DEFAULT_POOL_SIZE = 5
 
-
-def init_db(db_uri, max_connections=15):
-    max_overflow = max_connections - DEFAULT_POOL_SIZE
-    max_overflow = 10 if max_overflow < 10 else max_overflow
-    engine = create_engine(db_uri, max_overflow=max_overflow, pool_pre_ping=True)
+def init_db(db_uri, pool_size=16):
+    engine = create_engine(db_uri, pool_size=pool_size, pool_pre_ping=True)
     Session.configure(bind=engine)
 
 


### PR DESCRIPTION
Why:

* overflow connections are temporary and need to be reinstantiated for
  each requests.
* Benchmarks show about 10ms overhead for the new db connection to
  establish.
* We don't want that overhead for high-load environments.
* SQLAlchemy has a default max_overflow=10 that should be enough for
  non-http requests (e.g. token cleanup)
