### PR TITLE
token: try to decode authorization header in utf-8

### DIFF
--- a/wazo_auth/plugins/http/tokens/http.py
+++ b/wazo_auth/plugins/http/tokens/http.py
@@ -152,7 +152,7 @@ class Tokens(BaseResource):
         _, encoded_login_password = authorization.split('Basic ', 1)
         login_password = b64decode(encoded_login_password)
 
-        charsets = ['latin', 'utf-8']
+        charsets = ['utf-8', 'latin']
         for charset in charsets:
             try:
                 login_password = login_password.decode(charset)


### PR DESCRIPTION
ref: https://stackoverflow.com/questions/7242316/what-encoding-should-i-use-for-http-basic-authentication

also decoding a utf-8 encoded byte string with latin does not raise so the first attempt always works. testing with utf-8 first will raise an exception and fallback to latin