### PR TITLE
token: validate the max value for expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 23.17
+
+* Tokens now have a maximum expiration time of 10 years.
+
+
 ## 23.07
 
 * The following CLI options have been added

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -33,6 +33,21 @@ from .helpers.constants import UNKNOWN_UUID
 
 @base.use_asset('base')
 class TestTokens(base.APIIntegrationTest):
+    @fixtures.http.user(username='large', password='expiration')
+    def test_that_large_expiration_returns_a_400(self, _):
+        client = Client(
+            'localhost',
+            port=self.auth_port,
+            prefix=None,
+            https=False,
+            username='large',
+            password='expiration',
+        )
+        try:
+            client.token.new(backend='wazo_user', expiration=9999999999999999999999)
+        except HTTPError as e:
+            assert e.response.status_code == 400
+
     @fixtures.http.user(email_address='u1@example.com', password='bar')
     def test_that_the_email_can_be_used_to_get_a_token(self, u1):
         client = Client(

--- a/wazo_auth/plugins/http/tokens/api.yml
+++ b/wazo_auth/plugins/http/tokens/api.yml
@@ -44,6 +44,7 @@ paths:
             expiration:
               type: integer
               default: 7200
+              maximum: 315360000
               description: Expiration time in seconds.
             access_type:
               type: string

--- a/wazo_auth/plugins/http/tokens/schemas.py
+++ b/wazo_auth/plugins/http/tokens/schemas.py
@@ -9,10 +9,12 @@ from xivo.mallow.validate import Length, Range, OneOf
 
 from wazo_auth.schemas import BaseListSchema, BaseSchema
 
+TEN_YEARS = 3600 * 24 * 365 * 10
+
 
 class TokenRequestSchema(BaseSchema):
     backend = fields.String(missing='wazo_user')
-    expiration = fields.Integer(validate=Range(min=1))
+    expiration = fields.Integer(validate=Range(min=1, max=TEN_YEARS))
     access_type = fields.String(validate=OneOf(['online', 'offline']))
     client_id = fields.String(validate=Length(min=1, max=1024))
     refresh_token = fields.String()


### PR DESCRIPTION
super large values result in a psycopg2 error. based on sys.maxsize

I limited the expiration to 10 years which I guess is big enough for most people