### PR TITLE
WAZO-3600: prevent thread crashing when removing tokens without tenant_uuid

### DIFF
--- a/wazo_auth/token.py
+++ b/wazo_auth/token.py
@@ -190,19 +190,16 @@ class ExpiredTokenRemover:
                     event_args['tenant_uuid'] = token['metadata'].get('tenant_uuid')
                     break
             else:
-                logger.warning(
-                    'session without token associated: {}'.format(session['uuid'])
-                )
+                logger.warning('session without token associated: %s', session['uuid'])
 
             try:
                 event = event_class(**event_args)
             except ValueError:
-                cls_name = self.__class__.__name__
-                event_name = event_class.name
                 logger.debug(
-                    '{} failed to publish event `{}`, session has no tenant_uuid: {}'.format(
-                        cls_name, event_name, session['uuid']
-                    )
+                    '%s failed to publish event `%s`, session has no tenant_uuid: %s',
+                    self.__class__.__name__,
+                    event_class.name,
+                    session['uuid'],
                 )
             else:
                 self._bus_publisher.publish(event)

--- a/wazo_auth/token.py
+++ b/wazo_auth/token.py
@@ -141,7 +141,7 @@ class ExpiredTokenRemover:
                 log_level = logging.WARNING
             else:
                 log_level = logging.DEBUG
-            logger.log(log_level, "ExpiredTokenRemover tooks %s seconds", elapsed)
+            logger.log(log_level, "ExpiredTokenRemover took %s seconds", elapsed)
 
             if elapsed < self._cleanup_interval:
                 self._tombstone.wait(self._cleanup_interval - elapsed)

--- a/wazo_auth/token.py
+++ b/wazo_auth/token.py
@@ -197,6 +197,12 @@ class ExpiredTokenRemover:
             try:
                 event = event_class(**event_args)
             except ValueError:
-                logger.debug('session has no tenant_uuid: {}'.format(session['uuid']))
+                cls_name = self.__class__.__name__
+                event_name = event_class.name
+                logger.debug(
+                    '{} failed to publish event `{}`, session has no tenant_uuid: {}'.format(
+                        cls_name, event_name, session['uuid']
+                    )
+                )
             else:
                 self._bus_publisher.publish(event)

--- a/wazo_auth/token.py
+++ b/wazo_auth/token.py
@@ -193,5 +193,10 @@ class ExpiredTokenRemover:
                 logger.warning(
                     'session without token associated: {}'.format(session['uuid'])
                 )
-            event = event_class(**event_args)
-            self._bus_publisher.publish(event)
+
+            try:
+                event = event_class(**event_args)
+            except ValueError:
+                logger.debug('session has no tenant_uuid: {}'.format(session['uuid']))
+            else:
+                self._bus_publisher.publish(event)


### PR DESCRIPTION
Why:

* Because the event requires a tenant_uuid, when none are provided (such as email reset token) the ExpiredTokenRemover thread crashes while trying to create it.