### PR TITLE
Pull request for WP-1321-tenant-performance

### DIFF
--- a/integration_tests/performance_suite/conftest.py
+++ b/integration_tests/performance_suite/conftest.py
@@ -1,0 +1,1 @@
+../suite/conftest.py

--- a/integration_tests/performance_suite/helpers
+++ b/integration_tests/performance_suite/helpers
@@ -1,0 +1,1 @@
+../suite/helpers

--- a/integration_tests/performance_suite/test_tenants.py
+++ b/integration_tests/performance_suite/test_tenants.py
@@ -1,0 +1,34 @@
+# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import codetiming
+
+from .helpers import base, fixtures
+
+
+@base.use_asset('base')
+class TestTenants(base.APIIntegrationTest):
+    @fixtures.http.bulk_tenants()
+    def test_list_all_tenants(self):
+        top_tenant = self.get_top_tenant()
+
+        with codetiming.Timer() as timer:
+            result = self.client.tenants.list(tenant_uuid=top_tenant['uuid'])
+
+        assert timer.last < 1
+        assert result['total'] >= 5000
+
+    @fixtures.http.tenant(name='5k-subtenants-parent')
+    @fixtures.http.bulk_tenants(parent_name='5k-subtenants-parent')
+    def test_list_all_subtenants(self, parent_tenant):
+        with codetiming.Timer() as timer:
+            result = self.client.tenants.list(
+                tenant_uuid=parent_tenant['uuid'], recurse=True
+            )
+
+        assert timer.last < 5
+        assert result['total'] >= 5000
+
+    # TODO: test tenant creation performance
+    # TODO: test subtenant creation performance
+    # TODO: detect changes in database after rollback

--- a/integration_tests/performance_suite/test_tenants.py
+++ b/integration_tests/performance_suite/test_tenants.py
@@ -26,7 +26,7 @@ class TestTenants(base.APIIntegrationTest):
                 tenant_uuid=parent_tenant['uuid'], recurse=True
             )
 
-        assert timer.last < 5
+        assert timer.last < 10
         assert result['total'] >= 5000
 
     @fixtures.http.bulk_tenants()
@@ -41,6 +41,19 @@ class TestTenants(base.APIIntegrationTest):
         finally:
             self.client.tenants.delete(tenant['uuid'])
 
-    # TODO: test tenant creation performance
-    # TODO: test subtenant creation performance
+    @fixtures.http.tenant(name='create-subtenant-parent')
+    @fixtures.http.bulk_tenants()
+    def test_create_subtenant(self, parent_tenant):
+        with codetiming.Timer() as timer:
+            tenant = self.client.tenants.new(
+                name='performance-tenant-creation',
+                parent_uuid=parent_tenant['uuid'],
+                slug='perftc',
+            )
+
+        try:
+            assert timer.last < 0.1
+        finally:
+            self.client.tenants.delete(tenant['uuid'])
+
     # TODO: detect changes in database after rollback

--- a/integration_tests/performance_suite/test_tenants.py
+++ b/integration_tests/performance_suite/test_tenants.py
@@ -55,5 +55,3 @@ class TestTenants(base.APIIntegrationTest):
             assert timer.last < 0.1
         finally:
             self.client.tenants.delete(tenant['uuid'])
-
-    # TODO: detect changes in database after rollback

--- a/integration_tests/performance_suite/test_tenants.py
+++ b/integration_tests/performance_suite/test_tenants.py
@@ -29,6 +29,18 @@ class TestTenants(base.APIIntegrationTest):
         assert timer.last < 5
         assert result['total'] >= 5000
 
+    @fixtures.http.bulk_tenants()
+    def test_create_tenant(self):
+        with codetiming.Timer() as timer:
+            tenant = self.client.tenants.new(
+                name='performance-tenant-creation', slug='perftc'
+            )
+
+        try:
+            assert timer.last < 0.1
+        finally:
+            self.client.tenants.delete(tenant['uuid'])
+
     # TODO: test tenant creation performance
     # TODO: test subtenant creation performance
     # TODO: detect changes in database after rollback

--- a/integration_tests/suite/helpers/database.py
+++ b/integration_tests/suite/helpers/database.py
@@ -92,3 +92,6 @@ class DBSummary:
 
     def __str__(self):
         return str(self._tables)
+
+    def __len__(self):
+        return len(self._tables)

--- a/integration_tests/suite/helpers/fixtures/http.py
+++ b/integration_tests/suite/helpers/fixtures/http.py
@@ -95,6 +95,11 @@ def bulk_tenants(**tenant_args):
                 sql = '''DELETE FROM "auth_tenant" WHERE name LIKE 'bulk-tenants-%%';'''
                 db.inject_sql(sql)
 
+                final_diff = db.current_summary().diff(before)
+                assert (
+                    not final_diff
+                ), f'Fixture removal did not restore database as before: {final_diff}'
+
             return result
 
         return wrapper

--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -1,3 +1,4 @@
+codetiming
 kombu
 openapi-spec-validator<0.6.0  # dependency conflict on requests version (>2.31.0) with wazo clients (=2.25.1)
 pyhamcrest

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,22 @@ passenv =
     WAZO_TEST_DOCKER_OVERRIDE_EXTRA
 commands =
     make test-setup
-    pytest {posargs}
+    pytest {posargs:suite/}
+allowlist_externals =
+    make
+
+[testenv:performance]
+basepython = python3.9
+use_develop = true
+deps = -rintegration_tests/test-requirements-for-tox.txt
+changedir = integration_tests
+passenv =
+    INTEGRATION_TEST_TIMEOUT
+    WAZO_TEST_DOCKER_LOGS_DIR
+    WAZO_TEST_DOCKER_LOGS_ENABLED
+    WAZO_TEST_DOCKER_OVERRIDE_EXTRA
+commands =
+    make test-setup
+    pytest {posargs:performance_suite/}
 allowlist_externals =
     make

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -26,7 +26,9 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         return self.count([str(tenant_uuid)]) > 0
 
     def count(self, tenant_uuids, **kwargs):
-        filter_ = Tenant.uuid.in_(tenant_uuids)
+        filter_ = text('true')
+        if tenant_uuids is not None:
+            filter_ = Tenant.uuid.in_(tenant_uuids)
 
         filtered = kwargs.get('filtered')
         if filtered is not False:

--- a/wazo_auth/database/queries/tenant.py
+++ b/wazo_auth/database/queries/tenant.py
@@ -127,6 +127,41 @@ class TenantDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             .scalar()
         )
 
+    def is_subtenant(self, child_uuid, parent_uuid):
+        if parent_uuid is None or child_uuid is None:
+            return False
+
+        if parent_uuid == child_uuid:
+            return True
+
+        if not self.exists(child_uuid):
+            return False
+
+        top_tenant_uuid = self.find_top_tenant()
+        if parent_uuid == top_tenant_uuid:
+            return True
+
+        parent_tenants = (
+            self.session.query(Tenant.uuid)
+            .filter(Tenant.uuid == str(child_uuid))
+            .cte(recursive=True)
+        )
+        parent_tenants = parent_tenants.union_all(
+            self.session.query(Tenant.parent_uuid).filter(
+                and_(
+                    Tenant.uuid == parent_tenants.c.uuid,
+                    Tenant.uuid != parent_uuid,  # stop recursion on expected parent
+                    Tenant.uuid != Tenant.parent_uuid,  # stop recursion on top tenant
+                )
+            )
+        )
+
+        result = (
+            self.session.query(parent_tenants.c.uuid).select_from(parent_tenants).all()
+        )
+        uuid_chain = [row[0] for row in result]
+        return child_uuid in uuid_chain and parent_uuid in uuid_chain
+
     def list_visible_tenants(self, scoping_tenant_uuid=None):
         query = self._tenant_query(scoping_tenant_uuid)
         return query.all()

--- a/wazo_auth/flask_helpers.py
+++ b/wazo_auth/flask_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -37,8 +37,7 @@ class Tenant:
         if specified_tenant == user_tenant:
             return cls(user_tenant)
 
-        sub_tenants = cls._get_all_sub_tenants(user_tenant)
-        if specified_tenant in sub_tenants:
+        if cls._is_subtenant(specified_tenant, user_tenant):
             return cls(specified_tenant)
 
         raise tenant_helpers.UnauthorizedTenant(specified_tenant)
@@ -58,8 +57,8 @@ class Tenant:
         return user['tenant_uuid']
 
     @classmethod
-    def _get_all_sub_tenants(cls, tenant_uuid):
-        return cls.tenant_service.list_sub_tenants(tenant_uuid)
+    def _is_subtenant(cls, child_uuid, parent_uuid):
+        return cls.tenant_service.is_subtenant(child_uuid, parent_uuid)
 
     @classmethod
     def setup(cls, token_service, user_service, tenant_service):

--- a/wazo_auth/services/default_group.py
+++ b/wazo_auth/services/default_group.py
@@ -35,6 +35,9 @@ class DefaultGroupService:
             )
         commit_or_rollback()
 
+    def create_groups_for_new_tenant(self, tenant_uuid):
+        self.update_groups_for_tenant(tenant_uuid, {}, {})
+
     def update_groups_for_tenant(
         self, tenant_uuid, group_by_slug_tenant, policies_by_group
     ):

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -119,7 +119,7 @@ class TenantService(BaseService):
                 raise Exception('All users policy %s not found')
             self._dao.group.add_policy(all_users_group_uuid, all_users_policy.uuid)
 
-        self._default_group_service.update_groups([uuid])
+        self._default_group_service.create_groups_for_new_tenant(uuid)
 
         return result
 

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -31,7 +31,11 @@ class TenantService(BaseService):
             raise exceptions.UnknownTenantException(tenant_uuid)
 
     def count(self, scoping_tenant_uuid, **kwargs):
-        visible_tenants = self.list_sub_tenants(scoping_tenant_uuid)
+        top_tenant_uuid = self.find_top_tenant()
+        if scoping_tenant_uuid == top_tenant_uuid:
+            visible_tenants = None
+        else:
+            visible_tenants = self.list_sub_tenants(scoping_tenant_uuid)
         return self._dao.tenant.count(tenant_uuids=visible_tenants, **kwargs)
 
     def delete(self, scoping_tenant_uuid, tenant_uuid):
@@ -72,7 +76,11 @@ class TenantService(BaseService):
         raise exceptions.UnknownTenantException(tenant_uuid)
 
     def list_(self, scoping_tenant_uuid, **kwargs):
-        visible_tenants = self.list_sub_tenants(scoping_tenant_uuid)
+        top_tenant_uuid = self.find_top_tenant()
+        if scoping_tenant_uuid == top_tenant_uuid:
+            visible_tenants = None
+        else:
+            visible_tenants = self.list_sub_tenants(scoping_tenant_uuid)
         return self._dao.tenant.list_(tenant_uuids=visible_tenants, **kwargs)
 
     def list_sub_tenants(self, tenant_uuid):

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -29,11 +29,6 @@ class TenantService(BaseService):
         self._all_users_policies = all_users_policies
         self._default_group_service = default_group_service
 
-    def assert_tenant_under(self, scoping_tenant_uuid, tenant_uuid):
-        visible_tenants = self.list_sub_tenants(scoping_tenant_uuid)
-        if str(tenant_uuid) not in visible_tenants:
-            raise exceptions.UnknownTenantException(tenant_uuid)
-
     def count(self, scoping_tenant_uuid, **kwargs):
         top_tenant_uuid = self.find_top_tenant()
         if scoping_tenant_uuid == top_tenant_uuid:

--- a/wazo_auth/services/tenant.py
+++ b/wazo_auth/services/tenant.py
@@ -1,6 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
+
 from wazo_bus.resources.auth.events import (
     TenantCreatedEvent,
     TenantDeletedEvent,
@@ -9,6 +11,8 @@ from wazo_bus.resources.auth.events import (
 
 from wazo_auth import exceptions
 from wazo_auth.services.helpers import BaseService
+
+logger = logging.getLogger(__name__)
 
 
 class TenantService(BaseService):
@@ -121,6 +125,13 @@ class TenantService(BaseService):
 
         self._default_group_service.create_groups_for_new_tenant(uuid)
 
+        return result
+
+    def is_subtenant(self, child_uuid, parent_uuid):
+        result = self._dao.tenant.is_subtenant(child_uuid, parent_uuid)
+        logger.debug(
+            'Is tenant %s subtenant of %s? %s', child_uuid, parent_uuid, result
+        )
         return result
 
     def update(self, scoping_tenant_uuid, tenant_uuid, **kwargs):


### PR DESCRIPTION
## tests: add performance test on listing tenants


## tests: add performance test for listing subtenants


## performance tests: ensure db data is consistent with API

Why:

* This will raise an error if the API has a new side-effect in the
  database in the future
* We don't want to inject data that do not reflect reality

## tests: partially remove dependency on psql


## tests: replace sql file injection with fixture bulk_tenants


## tests: remove code for injecting sql file


## tests: move performance tests to their own directory

Why:

* Avoid slowing down functional integration tests with possibly
  long-running performance tests

## improve performance for tenant creation

Why:

* The update_groups iterates over all existing tenants, which is
  unnecessary when creating a new tenant

## tenants: improve subtenant creation


## performance tests: verify database is clean after test


## tox: separate integration tests from performance tests