### PR TITLE
test: fix compatibility with pytest 8.2.0 by removing properties

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -23,7 +23,6 @@ from hamcrest import (
     has_properties,
 )
 from kombu import Exchange
-from sqlalchemy.exc import UnboundExecutionError
 from wazo_auth_client import Client
 from wazo_test_helpers import until
 from wazo_test_helpers.asset_launching_test_case import (
@@ -70,21 +69,6 @@ class BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
     service = 'auth'
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        port = cls.service_port(5432, 'postgres')
-        db_uri = DB_URI.format(port=port)
-        helpers.init_db(db_uri)
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            helpers.deinit_db()
-        except UnboundExecutionError:
-            pass
-        super().tearDownClass()
-
-    @classmethod
     def make_auth_client(cls, username=None, password=None):
         try:
             port = cls.service_port(9497, service_name='auth')
@@ -106,6 +90,16 @@ class BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
             return WrongClient('postgres')
         db_uri = DB_URI.format(port=port)
         return Database(db_uri, db='asterisk')
+
+    @classmethod
+    def make_db_session(cls):
+        try:
+            port = cls.service_port(5432, 'postgres')
+        except (NoSuchService, NoSuchPort):
+            return WrongClient('postgres')
+
+        helpers.init_db(DB_URI.format(port=port))
+        return helpers.Session
 
     @classmethod
     def make_bus_client(cls):
@@ -159,9 +153,18 @@ class MetadataAssetLaunchingTestCase(BaseAssetLaunchingTestCase):
 
 class DAOTestCase(unittest.TestCase):
     unknown_uuid = '00000000-0000-0000-0000-000000000000'
+    asset_cls = DBAssetLaunchingTestCase
+
+    @classmethod
+    def setUpClass(cls):
+        cls.Session = cls.asset_cls.make_db_session()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.Session.get_bind().dispose()
+        cls.Session.remove()
 
     def setUp(self):
-        self.Session = helpers.Session
         self._address_dao = queries.AddressDAO()
         self._email_dao = queries.EmailDAO()
         self._external_auth_dao = queries.ExternalAuthDAO()
@@ -189,14 +192,14 @@ class DAOTestCase(unittest.TestCase):
 
     @property
     def session(self):
-        return helpers.get_db_session()
+        return self.Session()
 
     @contextmanager
     def check_db_requests(self, nb_requests):
         time_start = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-        nb_logs_start = DBAssetLaunchingTestCase.count_database_logs(since=time_start)
+        nb_logs_start = self.asset_cls.count_database_logs(since=time_start)
         yield
-        nb_logs_end = DBAssetLaunchingTestCase.count_database_logs(since=time_start)
+        nb_logs_end = self.asset_cls.count_database_logs(since=time_start)
         nb_db_requests = nb_logs_end - nb_logs_start
         assert_that(nb_db_requests, equal_to(nb_requests))
 
@@ -215,6 +218,12 @@ class BaseIntegrationTest(unittest.TestCase):
         super().setUpClass()
         cls.reset_clients()
         cls.top_tenant_uuid = cls.get_top_tenant()['uuid']
+        cls.Session = cls.asset_cls.make_db_session()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.Session.get_bind().dispose()
+        cls.Session.remove()
 
     @classmethod
     def reset_clients(cls):
@@ -225,6 +234,11 @@ class BaseIntegrationTest(unittest.TestCase):
         cls.admin_user_uuid = token['metadata']['uuid']
         cls.bus = cls.asset_cls.make_bus_client()
         cls.database = cls.asset_cls.make_db_client()
+        cls.Session = cls.asset_cls.make_db_session()
+
+    @property
+    def session(self):
+        return self.Session()
 
     @classmethod
     def auth_port(cls):

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -68,7 +68,6 @@ use_asset = pytest.mark.usefixtures
 class BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
     assets_root = os.path.join(os.path.dirname(__file__), '../..', 'assets')
     service = 'auth'
-    auth_host = '127.0.0.1'
 
     @classmethod
     def setUpClass(cls):
@@ -97,7 +96,7 @@ class BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
             kwargs['username'] = username
             kwargs['password'] = password
 
-        return Client(cls.auth_host, **kwargs)
+        return Client('127.0.0.1', **kwargs)
 
     @classmethod
     def make_db_client(cls):
@@ -227,17 +226,13 @@ class BaseIntegrationTest(unittest.TestCase):
         cls.bus = cls.asset_cls.make_bus_client()
         cls.database = cls.asset_cls.make_db_client()
 
-    @property
-    def auth_host(self):
-        return self.asset_cls.auth_host
+    @classmethod
+    def auth_port(cls):
+        return cls.asset_cls.service_port(9497, 'auth')
 
-    @property
-    def auth_port(self):
-        return self.asset_cls.service_port(9497, 'auth')
-
-    @property
-    def oauth2_port(self):
-        return self.asset_cls.service_port(80, 'oauth2sync')
+    @classmethod
+    def oauth2_port(cls):
+        return cls.asset_cls.service_port(80, 'oauth2sync')
 
     @classmethod
     def restart_auth(cls):

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -16,6 +16,6 @@ logger.setLevel(logging.INFO)
 @base.use_asset('base')
 class TestDocumentation(base.APIIntegrationTest):
     def test_documentation_errors(self):
-        api_url = f'http://{self.auth_host}:{self.auth_port}/0.1/api/api.yml'
+        api_url = f'http://127.0.0.1:{self.auth_port()}/0.1/api/api.yml'
         api = requests.get(api_url)
         validate_spec(yaml.safe_load(api.text), validator=openapi_v2_spec_validator)

--- a/integration_tests/suite/test_email_confirmation.py
+++ b/integration_tests/suite/test_email_confirmation.py
@@ -38,10 +38,7 @@ class TestEmailConfirmation(base.APIIntegrationTest):
     @fixtures.http.user_register(email_address='foobar@example.com')
     def test_email_confirmation_get(self, user):
         email_uuid = user['emails'][0]['uuid']
-
-        url = (
-            f'http://{self.auth_host}:{self.auth_port}/0.1/emails/{email_uuid}/confirm'
-        )
+        url = f'http://127.0.0.1:{self.auth_port()}/0.1/emails/{email_uuid}/confirm'
         token = self.client._token_id
         response = requests.get(url, params={'token': token})
         assert_that(response.status_code, equal_to(200))
@@ -63,7 +60,7 @@ class TestEmailConfirmation(base.APIIntegrationTest):
         self.client.users.request_confirmation_email(user['uuid'], email_uuid)
 
         expected_url = (
-            f'https://127.0.0.1:{self.auth_port}/0.1/emails/.*/confirm\\?token=.*'
+            f'https://127.0.0.1:{self.auth_port()}/0.1/emails/.*/confirm\\?token=.*'
         )
         self.assert_last_email(
             from_name='confirmation_from_name_sentinel',

--- a/integration_tests/suite/test_external.py
+++ b/integration_tests/suite/test_external.py
@@ -264,7 +264,7 @@ class TestExternalAuthAPI(base.ExternalAuthIntegrationTest):
         until.assert_(bus_received_msg, tries=10, interval=0.25)
 
     def authorize_oauth2(self, auth_type, state, token):
-        url = f'http://127.0.0.1:{self.oauth2_port}/{auth_type}/authorize/{state}'
+        url = f'http://127.0.0.1:{self.oauth2_port()}/{auth_type}/authorize/{state}'
         result = requests.get(url, params={'access_token': token})
         result.raise_for_status()
 

--- a/integration_tests/suite/test_external_google.py
+++ b/integration_tests/suite/test_external_google.py
@@ -117,7 +117,7 @@ class TestAuthGoogle(base.APIIntegrationTest):
         )
 
     def _simulate_user_authentication(self, state):
-        authorize_url = AUTHORIZE_URL.format(port=self.oauth2_port, state=state)
+        authorize_url = AUTHORIZE_URL.format(port=self.oauth2_port(), state=state)
         response = requests.get(authorize_url)
         response.raise_for_status()
 

--- a/integration_tests/suite/test_external_microsoft.py
+++ b/integration_tests/suite/test_external_microsoft.py
@@ -124,7 +124,7 @@ class TestAuthMicrosoft(base.APIIntegrationTest):
         )
 
     def _simulate_user_authentication(self, state):
-        authorize_url = AUTHORIZE_URL.format(port=self.oauth2_port, state=state)
+        authorize_url = AUTHORIZE_URL.format(port=self.oauth2_port(), state=state)
         response = requests.get(authorize_url)
         response.raise_for_status()
 

--- a/integration_tests/suite/test_http_interface.py
+++ b/integration_tests/suite/test_http_interface.py
@@ -63,7 +63,7 @@ class TestCore(base.APIIntegrationTest):
         )
 
     def test_backends(self):
-        url = f'http://{self.auth_host}:{self.auth_port}/0.1/backends'
+        url = f'http://127.0.0.1:{self.auth_port()}/0.1/backends'
         response = requests.get(url, verify=False)
         backends = ['broken_init', 'broken_verify_password', 'wazo_user', 'ldap_user']
         assert_that(response.json()['data'], contains_inanyorder(*backends))
@@ -134,7 +134,7 @@ class TestCore(base.APIIntegrationTest):
         )
 
     def test_that_no_type_returns_400(self):
-        url = f'http://{self.auth_host}:{self.auth_port}/0.1/token'
+        url = f'http://127.0.0.1:{self.auth_port()}/0.1/token'
         s = requests.Session()
         s.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
         s.auth = requests.auth.HTTPBasicAuth('foo', 'bar')

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -88,7 +88,7 @@ class TestPolicies(base.APIIntegrationTest):
             [None],
         ]
 
-        url = f'http://{self.auth_host}:{self.auth_port}/0.1/policies'
+        url = f'http://127.0.0.1:{self.auth_port()}/0.1/policies'
         headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',

--- a/integration_tests/suite/test_sessions.py
+++ b/integration_tests/suite/test_sessions.py
@@ -17,7 +17,6 @@ from hamcrest import (
 )
 from wazo_test_helpers import until
 
-from wazo_auth.database.helpers import get_db_session
 from wazo_auth.database.queries.token import TokenDAO
 
 from .helpers import base, fixtures
@@ -42,7 +41,7 @@ class TestSessions(base.APIIntegrationTest):
             'remote_addr': '',
         }
         _, session_uuid = TokenDAO().create(token_payload, {})
-        get_db_session().commit()  # force update in database
+        self.session.commit()  # force update in database
         return session_uuid
 
     @fixtures.http.session(mobile=False)

--- a/integration_tests/suite/test_sessions.py
+++ b/integration_tests/suite/test_sessions.py
@@ -28,10 +28,6 @@ TENANT_UUID_2 = str(uuid.uuid4())
 
 @base.use_asset('base')
 class TestSessions(base.APIIntegrationTest):
-    @property
-    def session(self):
-        return get_db_session()
-
     def _create_generic_token(self, expiration: int) -> str:
         now = int(time.time())
         token_payload = {
@@ -46,7 +42,7 @@ class TestSessions(base.APIIntegrationTest):
             'remote_addr': '',
         }
         _, session_uuid = TokenDAO().create(token_payload, {})
-        self.session.commit()  # force update in database
+        get_db_session().commit()  # force update in database
         return session_uuid
 
     @fixtures.http.session(mobile=False)

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -37,7 +37,7 @@ class TestTokens(base.APIIntegrationTest):
     def test_that_large_expiration_returns_a_400(self, _):
         client = Client(
             '127.0.0.1',
-            port=self.auth_port,
+            port=self.auth_port(),
             prefix=None,
             https=False,
             username='large',
@@ -52,7 +52,7 @@ class TestTokens(base.APIIntegrationTest):
     def test_that_the_email_can_be_used_to_get_a_token(self, u1):
         client = Client(
             '127.0.0.1',
-            port=self.auth_port,
+            port=self.auth_port(),
             prefix=None,
             https=False,
             username='u1@example.com',
@@ -64,7 +64,7 @@ class TestTokens(base.APIIntegrationTest):
     @fixtures.http.user(username=None, email_address='u1@example.com', password='pass1')
     @fixtures.http.user(username=None, email_address='u2@example.com', password='pass2')
     def test_that_the_email_can_be_used_to_get_a_token_when_many_users(self, u1, u2):
-        client = Client('127.0.0.1', port=self.auth_port, prefix=None, https=False)
+        client = Client('127.0.0.1', port=self.auth_port(), prefix=None, https=False)
 
         client.username = 'u1@example.com'
         client.password = 'pass1'
@@ -78,7 +78,7 @@ class TestTokens(base.APIIntegrationTest):
 
     @fixtures.http.user(username=None, email_address='u1@example.com', password='pépé')
     def test_unicode_password(self, u1):
-        client = Client('127.0.0.1', port=self.auth_port, prefix=None, https=False)
+        client = Client('127.0.0.1', port=self.auth_port(), prefix=None, https=False)
 
         client.username = 'u1@example.com'
         client.password = 'pépé'
@@ -102,7 +102,7 @@ class TestTokens(base.APIIntegrationTest):
 
     @fixtures.http.user(username=None, email_address='u1@example.com', password='pass')
     def test_username_is_logged_on_failed_attempts(self, u1):
-        client = Client('127.0.0.1', port=self.auth_port, prefix=None, https=False)
+        client = Client('127.0.0.1', port=self.auth_port(), prefix=None, https=False)
 
         client.username = 'u1@example.com'
         client.password = 'invalid'
@@ -116,7 +116,7 @@ class TestTokens(base.APIIntegrationTest):
 
     @fixtures.http.user(username=None, email_address='u1@example.com', password='pass')
     def test_username_is_logged_on_successful_attempts(self, u1):
-        client = Client('127.0.0.1', port=self.auth_port, prefix=None, https=False)
+        client = Client('127.0.0.1', port=self.auth_port(), prefix=None, https=False)
 
         client.username = 'u1@example.com'
         client.password = 'pass'

--- a/integration_tests/suite/test_users.py
+++ b/integration_tests/suite/test_users.py
@@ -79,7 +79,7 @@ class TestUsers(base.APIIntegrationTest):
             'password': 's3cr37',
         }
 
-        url = f'http://{self.auth_host}:{self.auth_port}/0.1/users'
+        url = f'http://127.0.0.1:{self.auth_port()}/0.1/users'
         result = requests.post(
             url,
             headers={'Content-Type': 'application/json'},


### PR DESCRIPTION
pytest 8.2.0 now read all properties of unittest class when collecting
items
- session: remove property to avoid fetching session before starting
  containers and have this session object in cache of sqlalchemy
- auth_port/oauth2_port: convert to methodclass instead of property to
  avoid to have lot of logs saying "no such service: oauth2" because
  containers are not started
- auth_host: was very weird since the value is localhost. This property
  was more misleading than helpful