### PR TITLE
[WP-1062] Add missing fields to external auth API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 24.07
+
+* The external API `POST /external/mobile/config` accepts a new key:
+
+  * `fcm_service_account_info`
+
+* The external API `POST /external/mobile/config` has a deprecated key:
+
+  * `fcm_api_key`
+
 ## 24.06
 
 * The config has new available keys:

--- a/wazo_auth/plugins/http/external/api.yml
+++ b/wazo_auth/plugins/http/external/api.yml
@@ -232,8 +232,16 @@ definitions:
       use_sandbox:
         description: Whether to use sandbox for Apple Push Notification Service
         type: boolean
+      fcm_sender_id:
+        description: The sender ID to use for Firebase Cloud Messaging
+        type: string
       fcm_api_key:
-        description: The API key to use for Firebase Cloud Messaging
+        description: The API key to use for Firebase Cloud Messaging (legacy)
+        type: string
+      fcm_service_account_info:
+        description: |
+          The service account info file to use for Firebase Cloud Messaging (v1). The
+          content should be JSON.
         type: string
 
 parameters:

--- a/wazo_auth/plugins/http/external/api.yml
+++ b/wazo_auth/plugins/http/external/api.yml
@@ -236,12 +236,12 @@ definitions:
         description: The sender ID to use for Firebase Cloud Messaging
         type: string
       fcm_api_key:
-        description: The API key to use for Firebase Cloud Messaging (legacy)
+        description: (deprecated) The API key to use for Firebase Cloud Messaging (legacy)
         type: string
       fcm_service_account_info:
         description: |
           The service account info file to use for Firebase Cloud Messaging (v1). The
-          content should be JSON.
+          content must be a JSON-encoded string.
         type: string
 
 parameters:


### PR DESCRIPTION
These fields are used by wazo-webhookd for push notifications