### PR TITLE
saml tests: move to a new asset

### DIFF
--- a/integration_tests/assets/docker-compose.saml.override.yml
+++ b/integration_tests/assets/docker-compose.saml.override.yml
@@ -2,13 +2,12 @@ services:
   sync:
     depends_on:
       - auth
-      - oauth2sync
       - postgres
       - rabbitmq
-      - smtp
-      - slapd
+      - proxy
+      - samlwebapp
     environment:
-      TARGETS: "slapd:1389 auth:9497 oauth2sync:80 postgres:5432 rabbitmq:5672 smtp:25"
+      TARGETS: "auth:9497 postgres:5432 rabbitmq:5672"
 
   auth:
     volumes:

--- a/integration_tests/functional_suite/test_saml.py
+++ b/integration_tests/functional_suite/test_saml.py
@@ -12,11 +12,11 @@ from playwright.sync_api import Page, expect
 from wazo_auth.database.queries.user import UserDAO
 
 from .helpers import base
-from .helpers.base import APIIntegrationTest
+from .helpers.base import SAMLIntegrationTest
 
 
-@base.use_asset('base')
-class TestSamlService(APIIntegrationTest):
+@base.use_asset('saml')
+class TestSamlService(SAMLIntegrationTest):
     @pytest.fixture(autouse=True)
     def setup(self, page: Page):
         self.page = page

--- a/integration_tests/suite/conftest.py
+++ b/integration_tests/suite/conftest.py
@@ -25,6 +25,15 @@ def base():
 
 
 @pytest.fixture(scope='session')
+def saml():
+    asset.SAMLAssetLaunchingTestCase.setUpClass()
+    try:
+        yield
+    finally:
+        asset.SAMLAssetLaunchingTestCase.tearDownClass()
+
+
+@pytest.fixture(scope='session')
 def database():
     asset.DBAssetLaunchingTestCase.setUpClass()
     try:

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -143,6 +143,10 @@ class APIAssetLaunchingTestCase(BaseAssetLaunchingTestCase):
     asset = 'base'
 
 
+class SAMLAssetLaunchingTestCase(BaseAssetLaunchingTestCase):
+    asset = 'saml'
+
+
 class ExternalAuthAssetLaunchingTestCase(BaseAssetLaunchingTestCase):
     asset = 'external_auth'
 
@@ -451,6 +455,12 @@ class APIIntegrationTest(BaseIntegrationTest):
 
         with _resource(create, delete, *args, **kwargs) as user:
             yield user
+
+
+class SAMLIntegrationTest(BaseIntegrationTest):
+    asset_cls = SAMLAssetLaunchingTestCase
+    username = 'admin'
+    password = 's3cre7'
 
 
 @contextmanager


### PR DESCRIPTION
I'm moving to a new asset to allow jenkins to execute all other tests while we figure out how to execute the saml tests