### PR TITLE
WAZO-2145: limit the number of sessions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         # Required to make flake8 read from pyproject.toml for now :(

--- a/integration_tests/assets/etc/wazo-auth/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/50-default.yml
@@ -43,4 +43,4 @@ saml:
         local:
           - '/var/lib/wazo-auth/saml/saml.xml'
 
-max_users_concurrent_sessions: 10
+max_user_concurrent_sessions: 10

--- a/integration_tests/assets/etc/wazo-auth/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/50-default.yml
@@ -42,3 +42,5 @@ saml:
       metadata:
         local:
           - '/var/lib/wazo-auth/saml/saml.xml'
+
+max_users_concurrent_sessions: 10

--- a/integration_tests/suite/helpers/constants.py
+++ b/integration_tests/suite/helpers/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -18,3 +18,5 @@ DEFAULT_POLICIES_SLUG = [
     'wazo_default_user_policy',
 ]
 NB_DEFAULT_POLICIES = len(DEFAULT_POLICIES_SLUG)
+
+MAXIMUM_CONCURRENT_USER_SESSIONS = 10  # from config['max_users_concurrent_sessions']

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -707,12 +707,7 @@ class TestTokens(base.APIIntegrationTest):
             client.token.new(expiration=10, access_type='online')
 
         assert_that(
-            calling(client.token.new).with_args(expiration=10, access_type='online'),
-            not_(
-                raises(HTTPError).matching(
-                    has_properties(response=has_properties(status_code=429))
-                )
-            ),
+            client.token.new(expiration=10, access_type='online'), has_key('token')
         )
 
 

--- a/integration_tests/suite/test_token.py
+++ b/integration_tests/suite/test_token.py
@@ -28,7 +28,7 @@ from wazo_test_helpers.hamcrest.raises import raises
 
 from .helpers import base, fixtures
 from .helpers.base import assert_http_error
-from .helpers.constants import UNKNOWN_UUID
+from .helpers.constants import MAXIMUM_CONCURRENT_USER_SESSIONS, UNKNOWN_UUID
 
 
 @base.use_asset('base')
@@ -670,6 +670,50 @@ class TestTokens(base.APIIntegrationTest):
                     )
                 ),
             )
+
+    @fixtures.http.user(username='foo', password='bar', purpose='user')
+    def test_user_maximum_token_limit(self, _):
+        client = self.make_auth_client('foo', 'bar')
+        for _ in range(MAXIMUM_CONCURRENT_USER_SESSIONS):
+            client.token.new(expiration=10, access_type='online')
+
+        # Fails on 11th token
+        assert_that(
+            calling(client.token.new).with_args(expiration=10, access_type='online'),
+            raises(HTTPError).matching(
+                has_properties(response=has_properties(status_code=429))
+            ),
+        )
+
+    @fixtures.http.user(
+        username='my-service', password='my-password', purpose='external_api'
+    )
+    def test_external_api_user_maximum_token_limit(self, _):
+        client = self.make_auth_client('my-service', 'my-password')
+        for _ in range(MAXIMUM_CONCURRENT_USER_SESSIONS):
+            client.token.new(expiration=10, access_type='online')
+
+        assert_that(
+            calling(client.token.new).with_args(expiration=10, access_type='online'),
+            raises(HTTPError).matching(
+                has_properties(response=has_properties(status_code=429))
+            ),
+        )
+
+    @fixtures.http.user(username='foo', password='bar', purpose='internal')
+    def test_internal_user_should_not_have_token_limit(self, _):
+        client = self.make_auth_client('foo', 'bar')
+        for _ in range(MAXIMUM_CONCURRENT_USER_SESSIONS):
+            client.token.new(expiration=10, access_type='online')
+
+        assert_that(
+            calling(client.token.new).with_args(expiration=10, access_type='online'),
+            not_(
+                raises(HTTPError).matching(
+                    has_properties(response=has_properties(status_code=429))
+                )
+            ),
+        )
 
 
 @base.use_asset('metadata')

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -129,6 +129,7 @@ _DEFAULT_CONFIG = {
         'key_file': '/var/lib/wazo-auth/saml/server.key',
         'cert_file': '/var/lib/wazo-auth/saml/server.crt',
     },
+    'max_users_concurrent_sessions': 100,
 }
 
 

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -129,7 +129,7 @@ _DEFAULT_CONFIG = {
         'key_file': '/var/lib/wazo-auth/saml/server.key',
         'cert_file': '/var/lib/wazo-auth/saml/server.crt',
     },
-    'max_users_concurrent_sessions': 100,
+    'max_user_concurrent_sessions': 100,
 }
 
 

--- a/wazo_auth/database/queries/session.py
+++ b/wazo_auth/database/queries/session.py
@@ -44,7 +44,7 @@ class SessionDAO(PaginatorMixin, BaseDAO):
             filter_ = and_(filter_, Session.tenant_uuid.in_(tenant_uuids))
 
         if user_uuid is not None:
-            filter_ = and_(filter_, Session.tokens.any(auth_id=user_uuid))
+            filter_ = and_(filter_, Session.tokens.any(auth_id=str(user_uuid)))
 
         return self.session.query(Session).join(Token).filter(filter_).count()
 

--- a/wazo_auth/database/queries/session.py
+++ b/wazo_auth/database/queries/session.py
@@ -35,13 +35,16 @@ class SessionDAO(PaginatorMixin, BaseDAO):
             for r in query.all()
         ]
 
-    def count(self, tenant_uuids=None, **kwargs):
+    def count(self, tenant_uuids=None, user_uuid=None, **kwargs):
         filter_ = text('true')
 
         if tenant_uuids is not None:
             if not tenant_uuids:
                 return 0
             filter_ = and_(filter_, Session.tenant_uuid.in_(tenant_uuids))
+
+        if user_uuid is not None:
+            filter_ = and_(filter_, Session.tokens.any(auth_id=user_uuid))
 
         return self.session.query(Session).join(Token).filter(filter_).count()
 

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -83,6 +83,12 @@ class InvalidListParamException(APIException):
                 return cls(info['message'], {field: info})
 
 
+class MaxConcurrentSessionsReached(APIException):
+    def __init__(self, details=None):
+        message = 'Unable to proceed, user has exceeded the maximum number of active sessions'
+        super().__init__(429, message, 'max-user-concurrent-sessions', details, 'users')
+
+
 class UnknownAddressException(APIException):
     def __init__(self, address_id):
         msg = f'No such address: "{address_id}"'

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -83,14 +83,6 @@ class InvalidListParamException(APIException):
                 return cls(info['message'], {field: info})
 
 
-class MaxConcurrentSessionsReached(APIException):
-    def __init__(self, details=None):
-        message = (
-            'Unable to proceed, user has exceeded the maximum number of active sessions'
-        )
-        super().__init__(429, message, 'max-user-concurrent-sessions', details, 'users')
-
-
 class UnknownAddressException(APIException):
     def __init__(self, address_id):
         msg = f'No such address: "{address_id}"'
@@ -358,6 +350,19 @@ class DuplicateAccessException(TokenServiceException):
 
     def __str__(self):
         return f'Policy already associated to {self._access}'
+
+
+class MaxConcurrentSessionsReached(TokenServiceException):
+    code = 429
+
+    def __init__(self, user_uuid):
+        super().__init__()
+        self._user_uuid = user_uuid
+
+    def __str__(self):
+        return (
+            f'User {self._user_uuid} has exceeded the maximum number of active sessions'
+        )
 
 
 class UnknownPolicyException(TokenServiceException):

--- a/wazo_auth/exceptions.py
+++ b/wazo_auth/exceptions.py
@@ -85,7 +85,9 @@ class InvalidListParamException(APIException):
 
 class MaxConcurrentSessionsReached(APIException):
     def __init__(self, details=None):
-        message = 'Unable to proceed, user has exceeded the maximum number of active sessions'
+        message = (
+            'Unable to proceed, user has exceeded the maximum number of active sessions'
+        )
         super().__init__(429, message, 'max-user-concurrent-sessions', details, 'users')
 
 

--- a/wazo_auth/services/token.py
+++ b/wazo_auth/services/token.py
@@ -79,7 +79,7 @@ class TokenService(BaseService):
         if is_uuid(auth_id) and purpose in ('user', 'external_api'):
             sessions = self._dao.session.count(user_uuid=auth_id)
             if sessions >= self._max_user_sessions:
-                raise MaxConcurrentSessionsReached({'user_uuid': auth_id})
+                raise MaxConcurrentSessionsReached(auth_id)
 
         args['acl'] = self._get_acl(args['backend'])
         args['metadata'] = metadata

--- a/wazo_auth/services/token.py
+++ b/wazo_auth/services/token.py
@@ -34,7 +34,7 @@ class TokenService(BaseService):
         self._default_expiration = config['default_token_lifetime']
         self._bus_publisher = bus_publisher
         self._user_service = user_service
-        self._max_user_sessions = config['max_users_concurrent_sessions']
+        self._max_user_sessions = config['max_user_concurrent_sessions']
 
     def count_refresh_tokens(
         self, scoping_tenant_uuid=None, recurse=False, **search_params

--- a/wazo_auth/services/token.py
+++ b/wazo_auth/services/token.py
@@ -16,6 +16,7 @@ from wazo_auth.token import Token
 
 from ..exceptions import (
     DuplicatedRefreshTokenException,
+    MaxConcurrentSessionsReached,
     MissingAccessTokenException,
     MissingTenantTokenException,
     UnknownTokenException,
@@ -33,6 +34,7 @@ class TokenService(BaseService):
         self._default_expiration = config['default_token_lifetime']
         self._bus_publisher = bus_publisher
         self._user_service = user_service
+        self._max_user_sessions = config['max_users_concurrent_sessions']
 
     def count_refresh_tokens(
         self, scoping_tenant_uuid=None, recurse=False, **search_params
@@ -72,6 +74,12 @@ class TokenService(BaseService):
         pbx_user_uuid = metadata.get('pbx_user_uuid')
         xivo_uuid = metadata['xivo_uuid']
         tenant_uuid = metadata.get('tenant_uuid')
+        purpose = metadata.get('purpose')
+
+        if is_uuid(auth_id) and purpose in ('user', 'external_api'):
+            sessions = self._dao.session.count(user_uuid=auth_id)
+            if sessions >= self._max_user_sessions:
+                raise MaxConcurrentSessionsReached({'user_uuid': auth_id})
 
         args['acl'] = self._get_acl(args['backend'])
         args['metadata'] = metadata


### PR DESCRIPTION
This PR proposes to introduce a maximum ceiling for the user's ability to create tokens/sessions.  

That maximum is configured in the config.py `max_users_concurrent_sessions` key and can be overriding in a configuration file but is not exposed by default

- By default, a user / external API users cannot create more than 100 tokens / sessions.  Beyond this limit a `429 Too many requests` response will be returned
- Internal users don't follow that limitation