### PR TITLE
move token extractor to email confirm

### DIFF
--- a/wazo_auth/http.py
+++ b/wazo_auth/http.py
@@ -16,11 +16,7 @@ from wazo_auth_client.exceptions import (
     MissingPermissionsTokenException,
 )
 from werkzeug.local import LocalProxy as Proxy
-from xivo.auth_verifier import (
-    AuthVerifier,
-    Unauthorized,
-    extract_token_id_from_query_or_header,
-)
+from xivo.auth_verifier import AuthVerifier, Unauthorized
 from xivo.auth_verifier import required_acl as _required_acl
 from xivo.auth_verifier import required_tenant
 from xivo.rest_api_helpers import handle_api_exception
@@ -85,7 +81,7 @@ class AuthClientFacade:
         self.users = self.UsersCommand()
 
 
-auth_verifier = AuthVerifier(extract_token_id=extract_token_id_from_query_or_header)
+auth_verifier = AuthVerifier()
 auth_verifier.set_client(AuthClientFacade())
 
 

--- a/wazo_auth/plugins/http/email_confirm/http.py
+++ b/wazo_auth/plugins/http/email_confirm/http.py
@@ -1,7 +1,8 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import Response
+from xivo.auth_verifier import extract_token_id_from_query_or_header
 
 from wazo_auth import http
 
@@ -12,7 +13,10 @@ class EmailConfirm(http.AuthResource):
         self._mimetype = config['email_confirmation_get_mimetype']
         self._get_body = template_formatter.get_confirmation_email_get_body()
 
-    @http.required_acl('auth.emails.{email_uuid}.confirm.edit')
+    @http.required_acl(
+        'auth.emails.{email_uuid}.confirm.edit',
+        extract_token_id=extract_token_id_from_query_or_header,
+    )
     def get(self, email_uuid):
         self.email_service.confirm(email_uuid)
         return Response(self._get_body, 200, mimetype=self._mimetype)


### PR DESCRIPTION
why: changing default extractor for the AuthVerifier was confusing
because most of resources use get_tenant_uuids method which hard code
usage of header. Then reading the code make you think query string was
accepted everywhere, but a 401 was raised further in the code

However, in all wazo services, the query string is only accepted on
specific endpoints. So it make more sense to move this check on specific
endpoint