### PR TITLE
WAZO-2542: process expired tokens/sessions in batches

### DIFF
--- a/integration_tests/suite/test_sessions.py
+++ b/integration_tests/suite/test_sessions.py
@@ -290,8 +290,8 @@ class TestSessions(base.APIIntegrationTest):
     def test_handle_generic_tokens_when_expired(self):
         assert self.client.config.get()['debug'] is True, 'debug must be set to true'
 
-        test_start: int = time.time()
-        session_uuid: str = self._create_generic_token(expiration=3)
+        test_start = time.time()
+        session_uuid = self._create_generic_token(expiration=3)
 
         def assert_log_message():
             logs = self.service_logs(service_name='auth', since=test_start)

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -20,6 +20,7 @@ _DEFAULT_CONFIG = {
     'profiling_enabled': False,
     'default_token_lifetime': TWO_HOURS,
     'token_cleanup_interval': 60.0,
+    'token_cleanup_batch_size': 5000,
     'password_reset_expiration': 172800,
     'password_reset_from_name': 'wazo-auth',
     'password_reset_from_address': 'noreply@wazo.community',


### PR DESCRIPTION
This PR modifies the ExpiredTokenRemover to process expired tokens and sessions in batches.  

The goal is prevent OOM errors when deleting too many tokens at once.  It will now process tokens and sessions by batches (5000 by default, configurable in config) until all expired tokens/sessions are removed.
