### PR TITLE
test: use latest wazo-base-db image to pass params

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -28,16 +28,7 @@ services:
     image: wazoplatform/wazo-auth-db:local
     ports:
       - "5432"
-    command:
-      - "/usr/lib/postgresql/13/bin/postgres"
-      - "-D"
-      - "/var/lib/postgresql/13/main"
-      - "--config-file=/etc/postgresql/13/main/postgresql.conf"
-      - "-c"
-      - "log_min_duration_statement=0"
-      - "-c"
-      - "fsync=off"
-
+    command: "-c 'log_min_duration_statement=0' -c 'fsync=off'"
 
   rabbitmq:
     image: rabbitmq

--- a/integration_tests/suite/test_db_token.py
+++ b/integration_tests/suite/test_db_token.py
@@ -56,11 +56,18 @@ class TestTokenDAO(base.DAOTestCase):
         )
 
         refresh_body = self._get_token_body()
-        refresh_body['refresh_token_uuid'] = refresh_token_uuid
-        token_uuid, session_uuid = self._token_dao.create(refresh_body, session)
+        token_uuid, session_uuid = self._token_dao.create(
+            {'refresh_token_uuid': refresh_token_uuid, **refresh_body},
+            session,
+        )
         result = self._token_dao.get(token_uuid)
         assert_that(
-            result, has_entries(uuid=token_uuid, session_uuid=session_uuid, **body)
+            result,
+            has_entries(
+                uuid=token_uuid,
+                session_uuid=session_uuid,
+                **refresh_body,
+            ),
         )
 
     @fixtures.db.token()


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-manage-db/pull/273
(it won't work until the Depends-on PR will be merged)

why: postgres command is now an entrypoint and parameter can be passed
as command