### PR TITLE
remove sqlalchemy warnings

### DIFF
--- a/integration_tests/suite/helpers/fixtures/http.py
+++ b/integration_tests/suite/helpers/fixtures/http.py
@@ -149,6 +149,8 @@ def user(**user_args):
         def wrapper(self, *args, **kwargs):
             user_args.setdefault('password', _random_string(20))
             user = self.client.users.new(**user_args)
+            assert 'password' not in user, 'The API should not return a password'
+            user['password'] = user_args['password']
             args = list(args) + [user]
             try:
                 result = decorated(self, *args, **kwargs)

--- a/integration_tests/suite/test_group_policy.py
+++ b/integration_tests/suite/test_group_policy.py
@@ -140,7 +140,7 @@ class TestGroupPolicyAssociation(base.APIIntegrationTest):
             tenant_uuid=SUB_TENANT_UUID,
         )
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     @fixtures.http.group()
     @fixtures.http.policy(acl=['authorized', '!forbid-access'])
     @fixtures.http.policy(acl=['authorized', 'unauthorized'])
@@ -148,7 +148,7 @@ class TestGroupPolicyAssociation(base.APIIntegrationTest):
     def test_put_when_policy_has_more_access_than_token(
         self, login, group, policy1, policy2, user_policy
     ):
-        user_client = self.make_auth_client('foo', 'bar')
+        user_client = self.make_auth_client('foo', login['password'])
         self.client.users.add_policy(login['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -226,12 +226,12 @@ class TestGroupPolicyAssociation(base.APIIntegrationTest):
     @fixtures.http.tenant(uuid=TENANT_UUID_1)
     @fixtures.http.group(name='one', tenant_uuid=TENANT_UUID_1)
     @fixtures.http.policy(name='main', acl=['foobar'])
-    @fixtures.http.user(username='foo', password='bar', tenant_uuid=TENANT_UUID_1)
+    @fixtures.http.user(username='foo', tenant_uuid=TENANT_UUID_1)
     def test_generated_acl(self, _, group, policy, user):
         self.client.groups.add_user(group['uuid'], user['uuid'])
         self.client.groups.add_policy(group['uuid'], policy['uuid'])
 
-        user_client = self.asset_cls.make_auth_client('foo', 'bar')
+        user_client = self.asset_cls.make_auth_client('foo', user['password'])
         token_data = user_client.token.new('wazo_user', expiration=5)
         assert_that(token_data, has_entries(acl=has_items('foobar')))
 

--- a/integration_tests/suite/test_policies.py
+++ b/integration_tests/suite/test_policies.py
@@ -180,10 +180,10 @@ class TestPolicies(base.APIIntegrationTest):
         with self.policy(self.client, name='first') as policy:
             assert_that(policy, has_entries(slug='first'))
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
     def test_post_when_policy_has_more_access_than_token(self, user, user_policy):
-        user_client = self.make_auth_client('foo', 'bar')
+        user_client = self.make_auth_client('foo', user['password'])
         self.client.users.add_policy(user['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -478,14 +478,14 @@ class TestPolicies(base.APIIntegrationTest):
             assert_http_error(403, client.policies.edit, policy['uuid'], 'name')
         assert_no_error(self.client.policies.edit, policy['uuid'], **policy)
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     @fixtures.http.policy()
     @fixtures.http.policy(acl=['authorized', '!anything', '!unauthorized'])
     @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
     def test_put_when_policy_has_more_access_than_token(
         self, user, policy_empty, policy_restrictive, user_policy
     ):
-        user_client = self.make_auth_client('foo', 'bar')
+        user_client = self.make_auth_client('foo', user['password'])
         self.client.users.add_policy(user['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -545,13 +545,13 @@ class TestPolicies(base.APIIntegrationTest):
             ),
         )
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
     @fixtures.http.policy()
     def test_add_access_when_policy_has_more_access_than_token(
         self, user, user_policy, policy
     ):
-        user_client = self.make_auth_client('foo', 'bar')
+        user_client = self.make_auth_client('foo', user['password'])
         self.client.users.add_policy(user['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -588,13 +588,13 @@ class TestPolicies(base.APIIntegrationTest):
         response = self.client.policies.get(policy['uuid'])
         assert_that(response, has_entries(acl=contains_inanyorder('dird.me.#')))
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     @fixtures.http.policy(acl=['authorized', '!unauthorized'])
     @fixtures.http.policy(acl=['auth.#', 'authorized', '!unauthorized'])
     def test_remove_access_when_negative_access_in_token(
         self, user, policy, user_policy
     ):
-        user_client = self.make_auth_client('foo', 'bar')
+        user_client = self.make_auth_client('foo', user['password'])
         self.client.users.add_policy(user['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)

--- a/integration_tests/suite/test_sessions.py
+++ b/integration_tests/suite/test_sessions.py
@@ -181,12 +181,12 @@ class TestSessions(base.APIIntegrationTest):
 
         until.assert_(bus_received_msg, tries=10, interval=0.25)
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     def test_create_event(self, user):
         headers = {'name': 'auth_session_created'}
         msg_accumulator = self.bus.accumulator(headers=headers)
 
-        session_uuid = self._post_token('foo', 'bar', session_type='Mobile')[
+        session_uuid = self._post_token('foo', user['password'], session_type='Mobile')[
             'session_uuid'
         ]
 
@@ -210,11 +210,13 @@ class TestSessions(base.APIIntegrationTest):
 
         until.assert_(bus_received_msg, tries=10, interval=0.25)
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     def test_expire_soon_event_when_token_is_about_to_expire(self, user):
         headers = {'name': 'auth_session_expire_soon'}
         msg_accumulator = self.bus.accumulator(headers=headers)
-        session_uuid = self._post_token('foo', 'bar', expiration=3)['session_uuid']
+        session_uuid = self._post_token('foo', user['password'], expiration=3)[
+            'session_uuid'
+        ]
 
         def bus_received_msg():
             assert_that(
@@ -235,12 +237,14 @@ class TestSessions(base.APIIntegrationTest):
 
         until.assert_(bus_received_msg, tries=10, interval=0.25)
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     def test_delete_event_when_token_expired(self, user):
         headers = {'name': 'auth_session_deleted'}
         msg_accumulator = self.bus.accumulator(headers=headers)
 
-        session_uuid = self._post_token('foo', 'bar', expiration=1)['session_uuid']
+        session_uuid = self._post_token('foo', user['password'], expiration=1)[
+            'session_uuid'
+        ]
 
         def bus_received_msg():
             assert_that(
@@ -261,12 +265,12 @@ class TestSessions(base.APIIntegrationTest):
 
         until.assert_(bus_received_msg, tries=10, interval=0.25)
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     def test_delete_event_when_token_deleted(self, user):
         headers = {'name': 'auth_session_deleted'}
         msg_accumulator = self.bus.accumulator(headers=headers)
 
-        token = self._post_token('foo', 'bar')
+        token = self._post_token('foo', user['password'])
         self.client.token.revoke(token['token'])
 
         def bus_received_msg():

--- a/integration_tests/suite/test_sessions.py
+++ b/integration_tests/suite/test_sessions.py
@@ -8,6 +8,7 @@ from hamcrest import (
     assert_that,
     contains_exactly,
     contains_string,
+    empty,
     greater_than_or_equal_to,
     has_entries,
     has_entry,
@@ -298,3 +299,13 @@ class TestSessions(base.APIIntegrationTest):
             assert_that(logs, contains_string(session_uuid))
 
         until.assert_(assert_log_message, tries=10, interval=0.5)
+
+    @fixtures.http.user(username='foo')
+    def test_that_delete_token_deletes_the_session(self, user):
+        token = self._post_token('foo', user['password'])
+        session_uuid = token['session_uuid']
+        sessions = self.client.users.get_sessions(user['uuid'])
+        assert_that(sessions['items'], contains_exactly(has_entries(uuid=session_uuid)))
+        self.client.token.revoke(token['token'])
+        sessions = self.client.users.get_sessions(user['uuid'])
+        assert_that(sessions['items'], empty())

--- a/integration_tests/suite/test_token_metadata.py
+++ b/integration_tests/suite/test_token_metadata.py
@@ -8,12 +8,12 @@ from .helpers import base, fixtures
 
 @base.use_asset('base')
 class TestDefaultTokenMetadata(base.APIIntegrationTest):
-    @fixtures.http.user(username='foobar', password='s3cr37', purpose='user')
+    @fixtures.http.user(username='foobar', purpose='user')
     @fixtures.http.group()
     def test_user_purpose_metadata(self, user, group):
         self.client.groups.add_user(group['uuid'], user['uuid'])
 
-        token_data = self._post_token(user['username'], 's3cr37')
+        token_data = self._post_token(user['username'], user['password'])
 
         assert_that(
             token_data['metadata'],
@@ -27,9 +27,9 @@ class TestDefaultTokenMetadata(base.APIIntegrationTest):
             ),
         )
 
-    @fixtures.http.user(username='foobar', password='s3cr37', purpose='internal')
+    @fixtures.http.user(username='foobar', purpose='internal')
     def test_internal_purpose_metadata(self, user):
-        token_data = self._post_token(user['username'], 's3cr37')
+        token_data = self._post_token(user['username'], user['password'])
 
         assert_that(
             token_data['metadata'],
@@ -43,9 +43,9 @@ class TestDefaultTokenMetadata(base.APIIntegrationTest):
             ),
         )
 
-    @fixtures.http.user(username='foobar', password='s3cr37', purpose='external_api')
+    @fixtures.http.user(username='foobar', purpose='external_api')
     def test_external_api_purpose_metadata(self, user):
-        token_data = self._post_token(user['username'], 's3cr37')
+        token_data = self._post_token(user['username'], user['password'])
 
         assert_that(
             token_data['metadata'],
@@ -62,9 +62,9 @@ class TestDefaultTokenMetadata(base.APIIntegrationTest):
 
 @base.use_asset('metadata')
 class TestUserAdminStatusMetadata(base.MetadataIntegrationTest):
-    @fixtures.http.user(username='foobar', password='s3cr37', purpose='user')
+    @fixtures.http.user(username='foobar', purpose='user')
     def test_admin_status_metadata_when_not_admin(self, user):
-        token_data = self._post_token(user['username'], 's3cr37')
+        token_data = self._post_token(user['username'], user['password'])
 
         assert_that(
             token_data['metadata'],
@@ -79,12 +79,12 @@ class TestUserAdminStatusMetadata(base.MetadataIntegrationTest):
             ),
         )
 
-    @fixtures.http.user(username='foobar', password='s3cr37', purpose='user')
+    @fixtures.http.user(username='foobar', purpose='user')
     def test_admin_status_metadata_when_admin(self, user):
         admin_policy = self.client.policies.get('wazo_default_admin_policy')
         self.client.users.add_policy(user['uuid'], admin_policy['uuid'])
 
-        token_data = self._post_token(user['username'], 's3cr37')
+        token_data = self._post_token(user['username'], user['password'])
 
         assert_that(
             token_data['metadata'],
@@ -99,13 +99,13 @@ class TestUserAdminStatusMetadata(base.MetadataIntegrationTest):
             ),
         )
 
-    @fixtures.http.user(username='foobar', password='s3cre37', purpose='user')
+    @fixtures.http.user(username='foobar', purpose='user')
     def test_admin_status_metadata_when_in_admin_group(self, user):
         group = self.client.groups.list(search='wazo_default_admin_group')['items'][0]
         self.client.groups.add_user(group['uuid'], user['uuid'])
 
         try:
-            token_data = self._post_token(user['username'], 's3cre37')
+            token_data = self._post_token(user['username'], user['password'])
         finally:
             self.client.groups.remove_user(group['uuid'], user['uuid'])
 

--- a/integration_tests/suite/test_user_group.py
+++ b/integration_tests/suite/test_user_group.py
@@ -161,7 +161,14 @@ class TestUserGroupAssociation(base.APIIntegrationTest):
         )
 
         result = self.client.groups.get_users(group['uuid'])
-        assert_that(result, has_entries(items=contains_inanyorder(user1)))
+        assert_that(
+            result,
+            has_entries(
+                items=contains_inanyorder(
+                    has_entries(uuid=user1['uuid']),
+                )
+            ),
+        )
 
         with self.client_in_subtenant() as (client, user3, _):
             action = client.groups.remove_user
@@ -207,7 +214,10 @@ class TestUserGroupAssociation(base.APIIntegrationTest):
         )
 
         result = self.client.groups.get_users(group['uuid'])
-        assert_that(result, has_entries(items=contains_inanyorder(user1)))
+        assert_that(
+            result,
+            has_entries(items=contains_inanyorder(has_entries(uuid=user1['uuid']))),
+        )
 
         with self.client_in_subtenant() as (client, user3, __):
             action = client.groups.add_user

--- a/integration_tests/suite/test_user_policy.py
+++ b/integration_tests/suite/test_user_policy.py
@@ -76,7 +76,7 @@ class TestUsers(base.APIIntegrationTest):
 
         assert_no_error(self.client.users.remove_policy, user['uuid'], policy_1['uuid'])
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     @fixtures.http.user()
     @fixtures.http.policy(acl=['authorized', '!forbid-access'])
     @fixtures.http.policy(acl=['authorized', 'unauthorized'])
@@ -84,7 +84,7 @@ class TestUsers(base.APIIntegrationTest):
     def test_put_when_policy_has_more_access_than_token(
         self, login, user, policy1, policy2, user_policy
     ):
-        user_client = self.make_auth_client('foo', 'bar')
+        user_client = self.make_auth_client('foo', login['password'])
         self.client.users.add_policy(login['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)
@@ -191,7 +191,7 @@ class TestUserPolicySlug(base.APIIntegrationTest):
             result = client.users.get_policies(visible_user['uuid'])
             assert_that(result, has_entries(items=empty()))
 
-    @fixtures.http.user(username='foo', password='bar')
+    @fixtures.http.user(username='foo')
     @fixtures.http.user()
     @fixtures.http.policy(acl=['authorized'])
     @fixtures.http.policy(acl=['authorized', '!unauthorized'])
@@ -202,7 +202,7 @@ class TestUserPolicySlug(base.APIIntegrationTest):
         self.client.users.add_policy(user['uuid'], policy1['uuid'])
         self.client.users.add_policy(user['uuid'], policy2['uuid'])
 
-        user_client = self.make_auth_client('foo', 'bar')
+        user_client = self.make_auth_client('foo', login['password'])
         self.client.users.add_policy(login['uuid'], user_policy['uuid'])
         token = user_client.token.new(expiration=30)['token']
         user_client.set_token(token)


### PR DESCRIPTION
(STDERR): /usr/lib/python3/dist-packages/sqlalchemy/orm/relationships.py:2273: SAWarning: On Token.session, 'passive_deletes' is normally configured on one-to-many, one-to-one, many-to-many relationships only.
(STDERR): /usr/lib/python3/dist-packages/sqlalchemy/orm/relationships.py:2273: SAWarning: On Policy.tenant, 'passive_deletes' is normally configured on one-to-many, one-to-one, many-to-many relationships only.