### PR TITLE
backport jinja2/markupsafe packages

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -16,7 +16,7 @@ https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 https://github.com/wazo-platform/wazo-bus/archive/master.zip
 sqlalchemy<2.0
-jinja2==2.11.3
+jinja2==3.0.3
 psycopg2-binary
 stevedore
 unidecode

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ flask-httpauth==3.2.4
 flask-restful==0.3.8
 flask==1.1.2
 itsdangerous==1.1.0  # from flask
-jinja2==2.11.3
+jinja2==3.0.3
 jsonpatch==1.25
 kombu==5.0.2
-markupsafe==1.1.1 # from jinja
+markupsafe==2.0.1 # from jinja
 marshmallow==3.10.0
 netifaces==0.10.9
 psycopg2-binary==2.8.6


### PR DESCRIPTION
why: to prepare Bookworm