### PR TITLE
alembic script_location now relative to config

### DIFF
--- a/wazo_auth/database/alembic.ini
+++ b/wazo_auth/database/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 # path to migration scripts
-script_location = wazo_auth:database/alembic
+script_location = %(here)s/alembic
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s


### PR DESCRIPTION
why: avoid 'alembic revision' depending on wazo-auth being installed in environement as an editable package(which is equivalent to using the project source directory instead of the installed python package, but is more complex and imposes specific workflow)
