### PR TITLE
Pull request for WP-1835-token-renewer-race-condition

### DIFF
--- a/wazo_auth/plugins/http/tokens/http.py
+++ b/wazo_auth/plugins/http/tokens/http.py
@@ -214,11 +214,10 @@ class Tokens(BaseResource):
             return http._error(401, 'Authentication Failed')
 
         token = self._token_service.new_token(backend, login, args)
-        redacted_token_id = 'XXXXXXXX-XXXX-XXXX-XXXX-XXXX' + token.token[-8:]
         logger.info(
             'Successful login: %s got token %s from %s using agent "%s"',
             login,
-            redacted_token_id,
+            token.token_redacted(),
             remote_addr,
             user_agent,
         )

--- a/wazo_auth/tests/test_helpers.py
+++ b/wazo_auth/tests/test_helpers.py
@@ -1,6 +1,7 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import time
 import unittest
 from unittest.mock import Mock
 
@@ -11,7 +12,9 @@ from ..helpers import LocalTokenRenewer
 
 class TestLocalTokenRenewer(unittest.TestCase):
     def setUp(self):
+        token = Mock(expire_t=time.time())
         self.token_service = Mock()
+        self.token_service.new_token_internal.return_value = token
         self.acl = ['access.1', 'access.2.#']
 
         self.token_renewer = LocalTokenRenewer(self.token_service, acl=self.acl)
@@ -45,3 +48,4 @@ class TestLocalTokenRenewer(unittest.TestCase):
         self.token_renewer.revoke_token()
 
         self.token_service.remove_token.assert_called_once_with(token)
+        assert_that(self.token_renewer._token, equal_to(None))

--- a/wazo_auth/token.py
+++ b/wazo_auth/token.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -104,6 +104,9 @@ class Token:
 
     def matches_required_access(self, required_access):
         return self._access_check.matches_required_access(required_access)
+
+    def token_redacted(self):
+        return 'XXXXXXXX-XXXX-XXXX-XXXX-XXXX' + self.token[-8:]
 
 
 class ExpiredTokenRemover:


### PR DESCRIPTION
## token renewer: make thread-safe

Why:

* Avoid race condition of one thread renewing the token while another
  continues with the old expired token

## token: use new helper token_redacted()

Why:

* Remove code duplication