### PR TITLE
backends: updated openapi endpoint description

### DIFF
--- a/wazo_auth/plugins/http/backends/api.yml
+++ b/wazo_auth/plugins/http/backends/api.yml
@@ -5,7 +5,7 @@ paths:
       - backends
       security:
       - {}
-      description: Retrieves the list of activated backends
+      description: Retrieves the list of activated wazo_auth.backends plugins
       responses:
         '200':
           description: The list of activated backends


### PR DESCRIPTION
Why: clarify the link to wazo_auth.backends plugins
