### PR TITLE
WAZO 4093 ldap idp

### DIFF
--- a/integration_tests/assets/etc/wazo-auth/conf.d/asset.base.yml
+++ b/integration_tests/assets/etc/wazo-auth/conf.d/asset.base.yml
@@ -8,6 +8,9 @@ idp_plugins:
   saml:
     enabled: true
     priority: 1
+  ldap:
+    enabled: true
+    priority: 2
   broken_load:
     enabled: true
     priority: 2

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,9 @@ setup(
             'default_external_api = wazo_auth.plugins.metadata.default_external_api:DefaultExternalAPI',  # noqa
             'user_admin_status = wazo_auth.plugins.metadata.user_admin_status:UserAdminStatus',
         ],
-        'wazo_auth.idp': ['saml = wazo_auth.plugins.idp.saml:SAMLIDP'],
+        'wazo_auth.idp': [
+            'saml = wazo_auth.plugins.idp.saml:SAMLIDP',
+            'ldap = wazo_auth.plugins.idp.ldap:LDAPIDP',
+        ],
     },
 )

--- a/wazo_auth/config.py
+++ b/wazo_auth/config.py
@@ -81,6 +81,10 @@ _DEFAULT_CONFIG = {
             'enabled': True,
             'priority': 1,
         },
+        'ldap': {
+            'enabled': True,
+            'priority': 2,
+        },
     },
     'backend_policies': {},  # since 21.14: Deprecated
     'rest_api': {

--- a/wazo_auth/controller.py
+++ b/wazo_auth/controller.py
@@ -252,7 +252,6 @@ class Controller:
 
         authentication_service = services.AuthenticationService(
             self.dao,
-            self._backends,
             self._tenant_service,
             dependencies['idp_plugins'],
             self._native_idp,

--- a/wazo_auth/plugins/idp/ldap.py
+++ b/wazo_auth/plugins/idp/ldap.py
@@ -1,0 +1,80 @@
+# Copyright 2025 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+from typing import TypedDict
+
+from stevedore.extension import Extension
+
+from wazo_auth.exceptions import InvalidUsernamePassword
+from wazo_auth.interfaces import BaseAuthenticationBackend
+
+from .base import BaseIDP, BaseIDPDependencies
+
+logger = logging.getLogger(__name__)
+
+
+class Backends(TypedDict, total=False):
+    ldap_user: Extension
+
+
+class Dependencies(BaseIDPDependencies):
+    backends: Backends
+
+
+class LDAPIDP(BaseIDP):
+    authentication_method = 'ldap'
+    loaded = False
+
+    _backend: BaseAuthenticationBackend
+
+    def load(self, dependencies: Dependencies):
+        logger.debug('Loading ldap idp plugin')
+        super().load(dependencies)
+
+        if 'ldap_user' not in dependencies['backends']:
+            logger.error(
+                'cannot load ldap idp plugin: missing wazo_auth.backends \'ldap_user\''
+            )
+            raise RuntimeError('missing ldap_user wazo_auth.backends extension')
+
+        self._backend = dependencies['backends']['ldap_user'].obj
+
+        self.loaded = True
+        logger.debug('ldap idp plugin loaded')
+
+    def can_authenticate(self, args: dict) -> bool:
+        return bool(
+            {'login', 'password'} <= set(args)
+            and {'domain_name', 'tenant_id'} & set(args)
+        )
+
+    def get_backend(self, args: dict) -> BaseAuthenticationBackend:
+        return self._backend
+
+    def verify_auth(self, args: dict) -> tuple[BaseAuthenticationBackend, str]:
+        assert self.loaded
+        assert {'login', 'password'} <= set(args)
+        assert {'domain_name', 'tenant_id'} & set(args)
+
+        ldap_login = args['login']
+        password = args['password']
+
+        logger.debug(
+            'verifying LDAP login for (username=%s, domain_name=%s, tenant_id=%s)',
+            ldap_login,
+            args.get('domain_name'),
+            args.get('tenant_id'),
+        )
+
+        if not self._backend.verify_password(ldap_login, password, args):
+            # TODO: should use ldap-specific exception
+            raise InvalidUsernamePassword(ldap_login)
+
+        # TODO: avoid relying on mutable args here
+        assert 'user_email' in args
+        login = args['user_email']
+
+        args['login'] = login
+
+        return self._backend, login

--- a/wazo_auth/plugins/idp/tests/test_ldap.py
+++ b/wazo_auth/plugins/idp/tests/test_ldap.py
@@ -1,0 +1,135 @@
+# Copyright 2025 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import sentinel as s
+
+import pytest
+
+from wazo_auth.exceptions import InvalidUsernamePassword
+from wazo_auth.plugins.idp.ldap import LDAPIDP, Dependencies
+
+
+@pytest.fixture
+def ldap_idp() -> LDAPIDP:
+    ldap_backend = MagicMock()
+
+    dependencies = {
+        'config': {},
+        'backends': {'ldap_user': MagicMock(obj=ldap_backend)},
+    }
+
+    idp = LDAPIDP()
+    idp.load(cast(Dependencies, dependencies))
+    return idp
+
+
+def test_can_authenticate(ldap_idp: LDAPIDP):
+    # valid LDAP auth parameters
+    assert ldap_idp.can_authenticate(
+        {
+            'login': s.login,
+            'password': s.password,
+            'domain_name': s.domain_name,
+        }
+    )
+    assert ldap_idp.can_authenticate(
+        {
+            'login': s.login,
+            'password': s.password,
+            'tenant_id': s.tenant_id,
+        }
+    )
+    # missing required parameters
+    assert not ldap_idp.can_authenticate(
+        {
+            'login': s.login,
+            'password': s.password,
+        }
+    )
+
+    assert not ldap_idp.can_authenticate(
+        {
+            'login': s.login,
+            'domain_name': s.domain_name,
+            'tenant_id': s.tenant_id,
+        }
+    )
+
+    assert not ldap_idp.can_authenticate({})
+
+
+def test_verify_auth_domain_name_ok(ldap_idp: LDAPIDP):
+    args = {
+        'login': s.login,
+        'password': s.password,
+        'domain_name': s.domain_name,
+    }
+
+    # Assume backend verifies password successfully
+    def update_args(login, password, args):
+        args['user_email'] = s.email
+        return True
+
+    ldap_idp._backend.verify_password.side_effect = update_args
+
+    backend, login = ldap_idp.verify_auth(args)
+    assert backend == ldap_idp._backend
+    assert login == s.email
+
+    # Verify the backend was called with the correct parameters
+    ldap_idp._backend.verify_password.assert_called_once_with(s.login, s.password, args)
+
+
+def test_verify_auth_domain_name_bad_credentials(ldap_idp: LDAPIDP):
+    args = {
+        'login': s.login,
+        'password': s.password,
+        'domain_name': s.domain_name,
+        'user_email': s.email,
+    }
+
+    # Assume backend fails to verify password
+    ldap_idp._backend.verify_password.return_value = False
+
+    with pytest.raises(InvalidUsernamePassword):
+        ldap_idp.verify_auth(args)
+
+
+def test_verify_auth_tenant_id_ok(ldap_idp: LDAPIDP):
+    args = {
+        'login': s.login,
+        'password': s.password,
+        'tenant_id': s.tenant_id,
+    }
+
+    # Assume backend verifies password successfully
+    def update_args(login, password, args):
+        args['user_email'] = s.email
+        return True
+
+    ldap_idp._backend.verify_password.side_effect = update_args
+
+    backend, login = ldap_idp.verify_auth(args)
+    assert backend == ldap_idp._backend
+    assert login == s.email
+
+    # Verify the backend was called with the correct parameters
+    ldap_idp._backend.verify_password.assert_called_once_with(s.login, s.password, args)
+
+
+def test_verify_auth_tenant_id_bad_credentials(ldap_idp: LDAPIDP):
+    args = {
+        'login': s.login,
+        'password': s.password,
+        'tenant_id': s.tenant_id,
+        'user_email': s.email,
+    }
+
+    # Assume backend fails to verify password
+    ldap_idp._backend.verify_password.return_value = False
+
+    with pytest.raises(InvalidUsernamePassword):
+        ldap_idp.verify_auth(args)

--- a/wazo_auth/services/idp.py
+++ b/wazo_auth/services/idp.py
@@ -13,7 +13,7 @@ from wazo_auth.services.helpers import BaseService
 IDPType = Union[str, Literal['default']]
 
 # TODO: remove non-native authentication methods when they are migrated to idp plugins
-HARDCODED_IDP_TYPES: set[IDPType] = {'ldap', 'native', 'default'}
+HARDCODED_IDP_TYPES: set[IDPType] = {'native', 'default'}
 
 
 class IDPService(BaseService):


### PR DESCRIPTION
- **idp: fixed typo on wazo_auth.backends**
- **saml: add saml idp plugin**
- **idp: migrated _get_user_auth_method to RefreshTokenIDP**
- **idp: added empty load impl. to BaseIDP**
- **copyright: fixed copyright dates**
- **idp: add ldap plugin**
- **test_authentication: use real RefreshTokenIDP**
- **ldap: use idp implementation**
