### PR TITLE
WP-1985-user-pagination

### DIFF
--- a/integration_tests/suite/helpers/fixtures/db.py
+++ b/integration_tests/suite/helpers/fixtures/db.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -48,8 +48,7 @@ def email(**email_args):
         @wraps(decorated)
         def wrapper(self, *args, **kwargs):
             email_args.setdefault('address', f'{_random_string(5)}@{_random_string(5)}')
-
-            def create_user():
+            if 'user_uuid' not in email_args:
                 user_args = {
                     'username': _random_string(5),
                     'purpose': 'user',
@@ -57,9 +56,7 @@ def email(**email_args):
                     'authentication_method': 'default',
                 }
                 user = self._user_dao.create(**user_args)
-                return user['uuid']
-
-            email_args.setdefault('user_uuid', create_user())
+                email_args['user_uuid'] = user['uuid']
 
             email = models.Email(**email_args)
             self.session.add(email)

--- a/integration_tests/suite/test_db_group.py
+++ b/integration_tests/suite/test_db_group.py
@@ -198,6 +198,58 @@ class TestGroupDAO(base.DAOTestCase):
         expected = build_list_matcher('baz', 'foo')
         assert_that(result, contains_exactly(*expected))
 
+    @fixtures.db.user()
+    @fixtures.db.user()
+    @fixtures.db.group(name='group1')
+    @fixtures.db.group(name='group2')
+    @fixtures.db.group(name='group3')
+    def test_list_with_many_users(self, user1, user2, group1, group2, group3):
+        self._group_dao.add_user(group1, user1)
+        self._group_dao.add_user(group1, user2)
+
+        result = self._group_dao.list_(order='name', direction='asc', limit=2)
+        assert_that(
+            result,
+            contains_exactly(has_entries(uuid=group1), has_entries(uuid=group2)),
+        )
+
+        result = self._group_dao.list_(order='name', direction='desc', limit=2)
+        assert_that(
+            result,
+            contains_exactly(has_entries(uuid=group3), has_entries(uuid=group2)),
+        )
+
+    @fixtures.db.user()
+    @fixtures.db.user()
+    @fixtures.db.group(name='group1')
+    @fixtures.db.group(name='group2')
+    @fixtures.db.group(name='group3')
+    def test_list_by_user_uuid(self, user1, user2, group1, group2, group3):
+        self._group_dao.add_user(group1, user1)
+        self._group_dao.add_user(group2, user1)
+
+        result = self._group_dao.list_(
+            user_uuid=user1,
+            order='name',
+            direction='asc',
+            limit=2,
+        )
+        assert_that(
+            result,
+            contains_exactly(has_entries(uuid=group1), has_entries(uuid=group2)),
+        )
+
+        result = self._group_dao.list_(
+            user_uuid=user1,
+            order='name',
+            direction='desc',
+            limit=2,
+        )
+        assert_that(
+            result,
+            contains_exactly(has_entries(uuid=group2), has_entries(uuid=group1)),
+        )
+
     @fixtures.db.group()
     @fixtures.db.policy()
     def test_remove_policy(self, group_uuid, policy_uuid):

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -587,6 +587,27 @@ class TestUserDAO(base.DAOTestCase):
         )
         assert_that(
             result, contains_inanyorder(has_entries(uuid=b), has_entries(uuid=c))
+        )
+
+    @fixtures.db.user(
+        uuid=USER_UUID,
+        username='user1',
+        email_address='user1-1@example.com',
+    )
+    @fixtures.db.user(username='user2')
+    @fixtures.db.user(username='user3')
+    @fixtures.db.email(user_uuid=USER_UUID, address='user1-2@example.com')
+    def test_pagination_with_many_emails(self, user1, user2, user3, email2):
+        result = self._user_dao.list_(order='username', direction='asc', limit=2)
+        assert_that(
+            result,
+            contains_exactly(has_entries(uuid=user1), has_entries(uuid=user2)),
+        )
+
+        result = self._user_dao.list_(order='username', direction='desc', limit=2)
+        assert_that(
+            result,
+            contains_exactly(has_entries(uuid=user3), has_entries(uuid=user2)),
         )
 
     @fixtures.db.user(username='a', firstname='a', lastname='a')

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -380,11 +380,8 @@ class TestUserDAO(base.DAOTestCase):
         assert_that(result, equal_to(3))
 
     @fixtures.db.user(username='a', email_address='a@example.com')
-    @fixtures.db.user(username='b', email_address='b@example.com')
-    @fixtures.db.user(username='c', email_address='c@example.com')
-    def test_user_list_no_search_term_no_strict_filter(self, a, b, c):
+    def test_user_list_returns_properties(self, a):
         result = self._user_dao.list_()
-
         assert_that(
             result,
             contains_inanyorder(
@@ -395,161 +392,62 @@ class TestUserDAO(base.DAOTestCase):
                     emails=contains_inanyorder(
                         has_entries(address='a@example.com', main=True, confirmed=False)
                     ),
-                ),
-                has_entries(
-                    uuid=b,
-                    username='b',
-                    tenant_uuid=self.top_tenant_uuid,
-                    emails=contains_inanyorder(
-                        has_entries(address='b@example.com', main=True, confirmed=False)
-                    ),
-                ),
-                has_entries(
-                    uuid=c,
-                    username='c',
-                    tenant_uuid=self.top_tenant_uuid,
-                    emails=contains_inanyorder(
-                        has_entries(address='c@example.com', main=True, confirmed=False)
-                    ),
-                ),
+                )
             ),
         )
 
-    @fixtures.db.user(
-        firstname='foo', lastname='foo', username='foo', email_address='foo@example.com'
-    )
-    @fixtures.db.user(
-        firstname='bar', lastname='bar', username='bar', email_address='bar@example.com'
-    )
-    @fixtures.db.user(
-        firstname='baz', lastname='baz', username='baz', email_address='baz@example.com'
-    )
+    @fixtures.db.user(username='a', email_address='a@example.com')
+    @fixtures.db.user(username='b', email_address='b@example.com')
+    @fixtures.db.user(username='c', email_address='c@example.com')
+    def test_user_list_no_search_term_no_strict_filter(self, a, b, c):
+        result = self._user_dao.list_()
+
+        assert_that(
+            result,
+            contains_inanyorder(
+                has_entries(uuid=a),
+                has_entries(uuid=b),
+                has_entries(uuid=c),
+            ),
+        )
+
+    @fixtures.db.user(email_address='foo@example.com')
+    @fixtures.db.user(email_address='bar@example.com')
+    @fixtures.db.user(email_address='baz@example.com')
     def test_user_list_with_search_term(self, foo, bar, baz):
         result = self._user_dao.list_(search='@example.')
 
         assert_that(
             result,
             contains_inanyorder(
-                has_entries(
-                    uuid=foo,
-                    username='foo',
-                    tenant_uuid=self.top_tenant_uuid,
-                    emails=contains_inanyorder(
-                        has_entries(
-                            address='foo@example.com', main=True, confirmed=False
-                        )
-                    ),
-                ),
-                has_entries(
-                    uuid=bar,
-                    username='bar',
-                    tenant_uuid=self.top_tenant_uuid,
-                    emails=contains_inanyorder(
-                        has_entries(
-                            address='bar@example.com', main=True, confirmed=False
-                        )
-                    ),
-                ),
-                has_entries(
-                    uuid=baz,
-                    username='baz',
-                    tenant_uuid=self.top_tenant_uuid,
-                    emails=contains_inanyorder(
-                        has_entries(
-                            address='baz@example.com', main=True, confirmed=False
-                        )
-                    ),
-                ),
+                has_entries(uuid=foo),
+                has_entries(uuid=bar),
+                has_entries(uuid=baz),
             ),
         )
 
         result = self._user_dao.list_(search='foo')
-        assert_that(
-            result,
-            contains_inanyorder(
-                has_entries(
-                    uuid=foo,
-                    username='foo',
-                    emails=contains_inanyorder(
-                        has_entries(
-                            address='foo@example.com', main=True, confirmed=False
-                        )
-                    ),
-                )
-            ),
-        )
+        assert_that(result, contains_inanyorder(has_entries(uuid=foo)))
 
-    @fixtures.db.user(
-        firstname='foo', lastname='foo', username='foo', email_address='foo@example.com'
-    )
-    @fixtures.db.user(
-        firstname='bar', lastname='bar', username='bar', email_address='bar@example.com'
-    )
-    @fixtures.db.user(
-        firstname='baz', lastname='baz', username='baz', email_address='baz@example.com'
-    )
+    @fixtures.db.user(username='foo', email_address='foo@example.com')
+    @fixtures.db.user(username='bar', email_address='bar@example.com')
+    @fixtures.db.user(username='baz', email_address='baz@example.com')
     def test_user_list_with_strict_filters(self, foo, bar, baz):
         result = self._user_dao.list_(username='foo')
-
-        assert_that(
-            result,
-            contains_inanyorder(
-                has_entries(
-                    uuid=foo,
-                    username='foo',
-                    emails=contains_inanyorder(
-                        has_entries(
-                            address='foo@example.com', main=True, confirmed=False
-                        )
-                    ),
-                )
-            ),
-        )
+        assert_that(result, contains_inanyorder(has_entries(uuid=foo)))
 
         result = self._user_dao.list_(uuid=foo)
-        assert_that(
-            result,
-            contains_inanyorder(
-                has_entries(
-                    uuid=foo,
-                    username='foo',
-                    emails=contains_inanyorder(
-                        has_entries(
-                            address='foo@example.com', main=True, confirmed=False
-                        )
-                    ),
-                )
-            ),
-        )
+        assert_that(result, contains_inanyorder(has_entries(uuid=foo)))
 
-    @fixtures.db.user(
-        firstname='foo', lastname='foo', username='foo', email_address='foo@example.com'
-    )
-    @fixtures.db.user(
-        firstname='bar', lastname='bar', username='bar', email_address='bar@example.com'
-    )
-    @fixtures.db.user(
-        firstname='baz', lastname='baz', username='baz', email_address='baz@example.com'
-    )
+    @fixtures.db.user(username='foo', email_address='foo@example.com')
+    @fixtures.db.user(username='bar', email_address='bar@example.com')
+    @fixtures.db.user(username='baz', email_address='baz@example.com')
     def test_user_list_with_strict_filters_and_search(self, foo, bar, baz):
         result = self._user_dao.list_(username='foo', search='baz')
         assert_that(result, empty())
 
         result = self._user_dao.list_(uuid=foo, search='example')
-        assert_that(
-            result,
-            contains_inanyorder(
-                has_entries(
-                    uuid=foo,
-                    username='foo',
-                    emails=contains_inanyorder(
-                        has_entries(
-                            address='foo@example.com', main=True, confirmed=False
-                        )
-                    ),
-                )
-            ),
-        )
+        assert_that(result, contains_inanyorder(has_entries(uuid=foo)))
 
     @fixtures.db.user(username='user1', email_address='user1@example.com')
     @fixtures.db.user(username='user2', email_address='user2@example.com')

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -523,6 +523,9 @@ class TestUserDAO(base.DAOTestCase):
             contains_exactly(has_entries(uuid=user3), has_entries(uuid=user2)),
         )
 
+        result = self._user_dao.count()
+        assert_that(result, equal_to(3))
+
     @fixtures.db.user(username='user1')
     @fixtures.db.user(username='user2')
     @fixtures.db.user(username='user3')

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -436,6 +436,9 @@ class TestUserDAO(base.DAOTestCase):
         result = self._user_dao.list_(username='foo')
         assert_that(result, contains_inanyorder(has_entries(uuid=foo)))
 
+        result = self._user_dao.list_(email_address='foo@example.com')
+        assert_that(result, contains_inanyorder(has_entries(uuid=foo)))
+
         result = self._user_dao.list_(uuid=foo)
         assert_that(result, contains_inanyorder(has_entries(uuid=foo)))
 

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -348,6 +348,7 @@ class User(Base):
     )
 
     emails = relationship('Email', viewonly=True)
+    user_groups = relationship('UserGroup', viewonly=True)
 
 
 class UserExternalAuth(Base):

--- a/wazo_auth/database/models.py
+++ b/wazo_auth/database/models.py
@@ -111,6 +111,8 @@ class Group(Base):
         Boolean, nullable=False, default=False, server_default='false'
     )
 
+    user_groups = relationship('UserGroup', viewonly=True)
+
 
 class GroupPolicy(Base):
     __tablename__ = 'auth_group_policy'
@@ -306,6 +308,8 @@ class Policy(Base):
 
     accesses = relationship('Access', secondary='auth_policy_access', viewonly=True)
     groups = relationship('Group', secondary='auth_group_policy', viewonly=True)
+    group_policies = relationship('GroupPolicy', viewonly=True)
+    user_policies = relationship('UserPolicy', viewonly=True)
 
     @property
     def acl(self):

--- a/wazo_auth/database/queries/filters.py
+++ b/wazo_auth/database/queries/filters.py
@@ -69,16 +69,6 @@ class SearchFilter:
             return '%{}%'.format('%'.join(words))
 
 
-class _TenantSearchFilter(SearchFilter):
-    def new_filter(self, search=None, **kwargs):
-        if search is None:
-            return text('true')
-
-        filter_ = super().new_filter(search, **kwargs)
-        pattern = self.new_pattern(search)
-        return or_(filter_, Tenant.domains.any(Domain.name.ilike(pattern)))
-
-
 class StrictFilter:
     def __init__(self, *column_configs):
         self._column_configs = column_configs
@@ -167,7 +157,11 @@ saml_session_strict_filter = StrictFilter(
 external_auth_search_filter = SearchFilter(ExternalAuthType.name)
 group_search_filter = SearchFilter(Group.name)
 policy_search_filter = SearchFilter(Policy.name, Policy.description)
-tenant_search_filter = _TenantSearchFilter(Tenant.name, Tenant.slug)
+tenant_search_filter = SearchFilter(
+    Tenant.name,
+    Tenant.slug,
+    AnyIlike(Tenant.domains, Domain.name),
+)
 user_search_filter = SearchFilter(
     User.firstname,
     User.lastname,

--- a/wazo_auth/database/queries/filters.py
+++ b/wazo_auth/database/queries/filters.py
@@ -118,15 +118,15 @@ group_strict_filter = StrictFilter(
     ('name', Group.name, None),
     ('slug', Group.slug, None),
     ('tenant_uuid', Group.tenant_uuid, str),
-    ('user_uuid', UserGroup.user_uuid, str),
+    ('user_uuid', AnyEquals(Group.user_groups, UserGroup.user_uuid), str),
     ('read_only', Group.system_managed, bool),
 )
 policy_strict_filter = StrictFilter(
     ('uuid', Policy.uuid, str),
     ('name', Policy.name, None),
     ('slug', Policy.slug, None),
-    ('user_uuid', UserPolicy.user_uuid, str),
-    ('group_uuid', GroupPolicy.group_uuid, str),
+    ('user_uuid', AnyEquals(Policy.user_policies, UserPolicy.user_uuid), str),
+    ('group_uuid', AnyEquals(Policy.group_policies, GroupPolicy.group_uuid), str),
     ('tenant_uuid', Policy.tenant_uuid, str),
 )
 refresh_token_strict_filter = StrictFilter(

--- a/wazo_auth/database/queries/filters.py
+++ b/wazo_auth/database/queries/filters.py
@@ -157,7 +157,7 @@ user_strict_filter = StrictFilter(
     ('lastname', User.lastname, None),
     ('purpose', User.purpose, None),
     ('email_address', AnyEquals(User.emails, Email.address), None),
-    ('group_uuid', UserGroup.group_uuid, str),
+    ('group_uuid', AnyEquals(User.user_groups, UserGroup.group_uuid), str),
 )
 saml_session_strict_filter = StrictFilter(
     ('session_id', SAMLSession.session_id, str),

--- a/wazo_auth/database/queries/group.py
+++ b/wazo_auth/database/queries/group.py
@@ -5,7 +5,7 @@ from sqlalchemy import and_, exc, text
 
 from ... import exceptions
 from ...slug import Slug
-from ..models import Email, Group, GroupPolicy, Policy, User, UserGroup
+from ..models import Group, GroupPolicy, Policy, User, UserGroup
 from . import filters
 from .base import BaseDAO, PaginatorMixin
 
@@ -104,13 +104,8 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             search_filter = filters.user_search_filter.new_filter(**kwargs)
             filter_ = and_(filter_, strict_filter, search_filter)
 
-        return (
-            self.session.query(UserGroup)
-            .join(User)
-            .outerjoin(Email)
-            .filter(filter_)
-            .count()
-        )
+        query = self.session.query(UserGroup).join(User).filter(filter_)
+        return query.count()
 
     def create(self, name, slug, tenant_uuid, system_managed, **ignored):
         if not slug:

--- a/wazo_auth/database/queries/group.py
+++ b/wazo_auth/database/queries/group.py
@@ -177,12 +177,7 @@ class GroupDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         if policy_slug:
             filter_ = and_(filter_, self._policy_slug_filter(policy_slug))
 
-        query = (
-            self.session.query(Group)
-            .outerjoin(UserGroup)
-            .filter(filter_)
-            .group_by(Group)
-        )
+        query = self.session.query(Group).filter(filter_)
         query = self._paginator.update_query(query, **kwargs)
 
         return [

--- a/wazo_auth/database/queries/policy.py
+++ b/wazo_auth/database/queries/policy.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import and_, exc, or_, text
@@ -198,21 +198,7 @@ class PolicyDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
 
         filter_ = and_(filter_, read_only_filter)
 
-        query = (
-            self.session.query(Policy)
-            .outerjoin(
-                UserPolicy,
-            )
-            .outerjoin(
-                GroupPolicy,
-            )
-            .filter(
-                filter_,
-            )
-            .group_by(
-                Policy,
-            )
-        )
+        query = self.session.query(Policy).filter(filter_)
         query = self._paginator.update_query(query, **kwargs)
 
         policies = query.all()

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -380,7 +380,7 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         filter_ = self._login_filter(login)
         if ignored_user:
             filter_ = and_(filter_, User.uuid != str(ignored_user))
-        query = self.session.query(User.uuid).outerjoin(Email).filter(filter_)
+        query = self.session.query(User.uuid).filter(filter_)
         exists = query.scalar()
         return True if exists else False
 

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -318,7 +318,6 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
         users = []
         query = (
             self.session.query(User)
-            .outerjoin(Email)
             .outerjoin(UserGroup)
             .options(joinedload('emails'))
             .filter(filter_)
@@ -394,7 +393,7 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
     def _login_filter(self, login):
         return or_(
             func.lower(User.username) == login.lower(),
-            func.lower(Email.address) == login.lower(),
+            User.emails.any(func.lower(Email.address) == login.lower()),
         )
 
     def _add_user_email(self, user_uuid, args):

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -109,7 +109,10 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             if has_policy_slug:
                 filter_ = and_(filter_, self._has_policy_slug_filter(has_policy_slug))
 
-        return self.session.query(User.uuid).outerjoin(Email).filter(filter_).count()
+        query = (
+            self.session.query(User.uuid).options(joinedload('emails')).filter(filter_)
+        )
+        return query.count()
 
     def count_groups(self, user_uuid, **kwargs):
         filtered = kwargs.get('filtered')

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -316,12 +316,7 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             filter_ = and_(filter_, self._login_filter(login))
 
         users = []
-        query = (
-            self.session.query(User)
-            .outerjoin(UserGroup)
-            .options(joinedload('emails'))
-            .filter(filter_)
-        )
+        query = self.session.query(User).options(joinedload('emails')).filter(filter_)
         query = self._paginator.update_query(query, **kwargs)
 
         for user in query.all():

--- a/wazo_auth/database/queries/user.py
+++ b/wazo_auth/database/queries/user.py
@@ -1,7 +1,7 @@
 # Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy import and_, exc, func, or_, text
+from sqlalchemy import and_, distinct, exc, func, or_, text
 from sqlalchemy.orm import joinedload
 
 from ... import exceptions
@@ -109,9 +109,7 @@ class UserDAO(filters.FilterMixin, PaginatorMixin, BaseDAO):
             if has_policy_slug:
                 filter_ = and_(filter_, self._has_policy_slug_filter(has_policy_slug))
 
-        query = (
-            self.session.query(User.uuid).options(joinedload('emails')).filter(filter_)
-        )
+        query = self.session.query(distinct(User.uuid)).filter(filter_)
         return query.count()
 
     def count_groups(self, user_uuid, **kwargs):


### PR DESCRIPTION
- **test: fix wrong usage of setdefault**
- **user: fix wrong pagination when many emails**
- **test: refactor user list to be more readable**
- **test: add test for email_address strict filter**
- **user: use ORM to search in relationship**
- **user: fix wrong pagination when many groups**
- **tenant: use AnyIlike filter to search on relationship**
- **fix wrong count when many emails to a user**
- **user: rewrite query to be more readable**
- **user: remove duplicate join for email**
- **fix wrong count_users from group dao**
- **ensure best practice for list dao**
