### PR TITLE
integration_tests: switch bitnami image to legacy repo

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "5672"
 
   slapd:
-    image: bitnami/openldap
+    image: bitnamilegacy/openldap
     environment:
       BITNAMI_DEBUG: "true"
       LDAP_PORT_NUMBER: 1389


### PR DESCRIPTION
why: bitnami/openldap images disappeared from the dockerhub repo
